### PR TITLE
Dark mode, fix keyboard nav, fix analytics tracking, add preview button

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,15 +10,37 @@ import Analytics from './pages/Analytics';
 
 const APP_VERSION = '0.6.0';
 
+function getInitialTheme() {
+  return localStorage.getItem('of_theme') || 'auto';
+}
+
 export default function App() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [theme, setTheme] = useState(getInitialTheme);
   const navigate = useNavigate();
   const location = useLocation();
 
   useEffect(() => {
     api.me().then(d => setUser(d.user)).catch(() => setUser(null)).finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'auto') {
+      root.removeAttribute('data-theme');
+    } else {
+      root.setAttribute('data-theme', theme);
+    }
+    localStorage.setItem('of_theme', theme);
+  }, [theme]);
+
+  function cycleTheme() {
+    setTheme(prev => prev === 'auto' ? 'dark' : prev === 'dark' ? 'light' : 'auto');
+  }
+
+  const themeIcon = theme === 'dark' ? '🌙' : theme === 'light' ? '☀️' : '🖥️';
+  const themeLabel = theme === 'dark' ? 'Dark' : theme === 'light' ? 'Light' : 'Auto';
 
   if (loading) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
 
@@ -44,6 +66,9 @@ export default function App() {
         </nav>
         <div style={{ marginTop: 'auto', paddingTop: 16 }}>
           <span style={{ fontSize: 13, opacity: 0.5, display: 'block', padding: '0 12px', marginBottom: 8 }}>{user.email}</span>
+          <button className="theme-toggle" onClick={cycleTheme}>
+            <span className="theme-toggle-icon">{themeIcon}</span> {themeLabel}
+          </button>
           <button onClick={handleLogout} style={{ background: 'none', border: 'none', color: 'rgba(255,255,255,0.5)', fontSize: 13, padding: '8px 12px', cursor: 'pointer' }}>
             Log out
           </button>

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -139,7 +139,7 @@ export default function FormEditor() {
             <input
               value={form.title}
               onChange={e => setForm({ ...form, title: e.target.value })}
-              style={{ fontSize: 24, fontWeight: 700, border: 'none', background: 'none', padding: 0, outline: 'none', width: 400 }}
+              style={{ fontSize: 24, fontWeight: 700, border: 'none', background: 'none', padding: 0, outline: 'none', width: 400, color: 'var(--text)' }}
             />
             <span className={`badge ${form.published ? 'badge-published' : 'badge-draft'}`}>
               {form.published ? 'Live' : 'Draft'}
@@ -148,6 +148,17 @@ export default function FormEditor() {
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           {saved && <span style={{ color: '#00B894', fontSize: 13 }}>Saved!</span>}
+          {form.published ? (
+            <a
+              href={`${baseUrl}/embed/${form.slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn btn-secondary"
+              style={{ textDecoration: 'none' }}
+            >
+              Open Preview &#8599;
+            </a>
+          ) : null}
           <button className="btn btn-secondary" onClick={() => save({ published: form.published ? 0 : 1 })}>
             {form.published ? 'Unpublish' : 'Publish'}
           </button>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -16,6 +16,32 @@
   --danger: #E17055;
   --radius: 12px;
   --shadow: 0 2px 12px rgba(0,0,0,0.08);
+  --sidebar-bg: #2D3436;
+  --input-bg: transparent;
+}
+
+[data-theme="dark"] {
+  --bg: #1a1a2e;
+  --card: #232342;
+  --text: #E0E0E0;
+  --text-light: #A0A0B0;
+  --border: #3a3a5c;
+  --shadow: 0 2px 12px rgba(0,0,0,0.3);
+  --sidebar-bg: #16162a;
+  --input-bg: #2a2a4a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #1a1a2e;
+    --card: #232342;
+    --text: #E0E0E0;
+    --text-light: #A0A0B0;
+    --border: #3a3a5c;
+    --shadow: 0 2px 12px rgba(0,0,0,0.3);
+    --sidebar-bg: #16162a;
+    --input-bg: #2a2a4a;
+  }
 }
 
 body {
@@ -44,7 +70,7 @@ input, select, textarea {
 
 .admin-sidebar {
   width: 240px;
-  background: var(--text);
+  background: var(--sidebar-bg);
   color: white;
   padding: 24px 16px;
   display: flex;
@@ -137,7 +163,33 @@ input, select, textarea {
 }
 
 .btn-secondary:hover {
-  background: #c8d6db;
+  background: var(--border);
+  opacity: 0.8;
+}
+
+/* Theme toggle */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: rgba(255,255,255,0.5);
+  cursor: pointer;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+}
+
+.theme-toggle:hover {
+  color: rgba(255,255,255,0.8);
+}
+
+.theme-toggle-icon {
+  font-size: 16px;
+  width: 20px;
+  text-align: center;
 }
 
 .btn-danger {
@@ -159,6 +211,8 @@ input, select, textarea {
   font-size: 16px;
   transition: border-color 0.2s;
   outline: none;
+  background: var(--input-bg);
+  color: var(--text);
 }
 
 .input:focus {


### PR DESCRIPTION
- Add dark/light/auto theme with CSS variables and prefers-color-scheme
- Add theme cycle toggle (Auto → Dark → Light) in sidebar profile area
- Persist theme preference in localStorage
- Fix keyboard navigation: auto-focus selection containers with useRef, stopPropagation on child keyDown so parent Enter handler still works
- Fix analytics sendBeacon: use Blob with application/json Content-Type so Express can parse the request body
- Add "Open Preview" button in form builder header when form is published
- Dark mode: sidebar, cards, inputs, borders all respect theme variables

https://claude.ai/code/session_01EVFYvCmRyrxxH5PcrqcdD2