### PR TITLE
Fix form deletion and isolate dark mode from public preview

### DIFF
--- a/backend/src/routes/forms.js
+++ b/backend/src/routes/forms.js
@@ -98,6 +98,8 @@ router.delete('/:id', (req, res) => {
   const db = getDb();
   const existing = db.prepare('SELECT id FROM forms WHERE id = ? AND user_id = ?').get(req.params.id, req.userId);
   if (!existing) return res.status(404).json({ error: 'Form not found' });
+  db.prepare('DELETE FROM analytics_events WHERE form_id = ?').run(req.params.id);
+  db.prepare('DELETE FROM integrations WHERE form_id = ?').run(req.params.id);
   db.prepare('DELETE FROM submissions WHERE form_id = ?').run(req.params.id);
   db.prepare('DELETE FROM forms WHERE id = ?').run(req.params.id);
   res.json({ ok: true });

--- a/frontend/src/pages/EmbedView.jsx
+++ b/frontend/src/pages/EmbedView.jsx
@@ -8,6 +8,17 @@ export default function EmbedView() {
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
 
+  // Force light theme on embedded form pages (dark mode is admin-only)
+  useEffect(() => {
+    const root = document.documentElement;
+    const prev = root.getAttribute('data-theme');
+    root.setAttribute('data-theme', 'light');
+    return () => {
+      if (prev) root.setAttribute('data-theme', prev);
+      else root.removeAttribute('data-theme');
+    };
+  }, []);
+
   useEffect(() => {
     api.getPublicForm(slug).then(d => setForm(d.form)).catch(e => setError(e.message));
   }, [slug]);

--- a/frontend/src/pages/FormView.jsx
+++ b/frontend/src/pages/FormView.jsx
@@ -8,6 +8,17 @@ export default function FormView() {
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
 
+  // Force light theme on public form pages (dark mode is admin-only)
+  useEffect(() => {
+    const root = document.documentElement;
+    const prev = root.getAttribute('data-theme');
+    root.setAttribute('data-theme', 'light');
+    return () => {
+      if (prev) root.setAttribute('data-theme', prev);
+      else root.removeAttribute('data-theme');
+    };
+  }, []);
+
   useEffect(() => {
     api.getPublicForm(slug).then(d => setForm(d.form)).catch(e => setError(e.message));
   }, [slug]);


### PR DESCRIPTION
- Delete analytics_events and integrations before deleting a form (foreign key constraints were blocking deletion for forms with data)
- Force light theme on public form and embed views so dark mode only affects the admin interface

https://claude.ai/code/session_01EVFYvCmRyrxxH5PcrqcdD2