### PR TITLE
fix: security, reliability, and usability refactor (v0.7.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.7.5] - 2026-04-16
+
+### Fixed
+- **Security: admin-only user deletion** — `DELETE /users/:id` now correctly requires admin role; previously any authenticated user could delete any account
+- **Security: JWT secret warning** — Server now logs a warning at startup when `JWT_SECRET` is not set in the environment
+- **Backend: JSON parse safety** — `JSON.parse()` calls on stored form data in routes are now wrapped in try/catch; corrupted records return a 500 error instead of crashing the handler
+- **Backend: analytics event validation** — `/api/public/track` now validates that the given `formId` exists before inserting the event (previously orphaned rows could accumulate)
+- **Backend: atomic form deletion** — Cascaded deletes of submissions, integrations, and analytics events now run inside a single SQLite transaction
+- **Backend: IP detection behind proxies** — Rate limiters now read `X-Forwarded-For` first, falling back to `req.ip`, so limits are correctly applied when OpenFlow runs behind a reverse proxy
+- **Backend: analytics error logging** — Analytics insert failures are now logged instead of silently swallowed
+- **Frontend: 401 redirect safety** — The API client now throws after redirecting to `/login` on a 401, stopping subsequent code from running with a stale session
+- **Frontend: error states** — Dashboard, Analytics, FormEditor, Submissions, and IntegrationsPanel all show error messages when API calls fail instead of silently leaving the user on an empty/loading screen
+- **Frontend: IntegrationsPanel double-click** — "Add integration" buttons are disabled while a creation request is in flight to prevent duplicate integrations
+- **Frontend: auto-advance stale closure** — The auto-advance timer in FormRenderer now checks a step ref at fire time; it no longer advances the form if the user has already navigated to a different step in the 400 ms window
+
 ## [0.7.4] - 2026-02-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.7.4
+# 🌊 OpenFlow v0.7.5
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "1.0.0",
+  "version": "0.7.5",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -39,7 +39,7 @@ app.get('*', (req, res) => {
   if (fs.existsSync(indexPath)) {
     res.sendFile(indexPath);
   } else {
-    res.status(200).json({ status: 'OpenFlow API running', version: '0.7.4' });
+    res.status(200).json({ status: 'OpenFlow API running', version: '0.7.5' });
   }
 });
 

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,6 +1,9 @@
 const jwt = require('jsonwebtoken');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'change-me-in-production';
+if (!process.env.JWT_SECRET) {
+  console.warn('WARNING: JWT_SECRET is not set. Using default insecure secret. Set JWT_SECRET in production!');
+}
 
 function authMiddleware(req, res, next) {
   const token = req.cookies.token || req.headers.authorization?.replace('Bearer ', '');

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -99,8 +99,8 @@ router.put('/users/:id', authMiddleware, requireAdmin, (req, res) => {
   res.json({ user: updated });
 });
 
-// Delete user (any authenticated user can delete, but cannot delete themselves)
-router.delete('/users/:id', authMiddleware, (req, res) => {
+// Delete user (admin only)
+router.delete('/users/:id', authMiddleware, requireAdmin, (req, res) => {
   try {
     const db = getDb();
     if (req.params.id === req.userId) {

--- a/backend/src/routes/forms.js
+++ b/backend/src/routes/forms.js
@@ -25,9 +25,13 @@ router.get('/:id', (req, res) => {
   const db = getDb();
   const form = db.prepare('SELECT * FROM forms WHERE id = ? AND user_id = ?').get(req.params.id, req.userId);
   if (!form) return res.status(404).json({ error: 'Form not found' });
-  form.steps = JSON.parse(form.steps);
-  form.end_screen = JSON.parse(form.end_screen);
-  form.theme = JSON.parse(form.theme);
+  try {
+    form.steps = JSON.parse(form.steps);
+    form.end_screen = JSON.parse(form.end_screen);
+    form.theme = JSON.parse(form.theme);
+  } catch {
+    return res.status(500).json({ error: 'Form data is corrupted' });
+  }
   res.json({ form });
 });
 
@@ -52,9 +56,13 @@ router.post('/', (req, res) => {
   );
 
   const form = db.prepare('SELECT * FROM forms WHERE id = ?').get(id);
-  form.steps = JSON.parse(form.steps);
-  form.end_screen = JSON.parse(form.end_screen);
-  form.theme = JSON.parse(form.theme);
+  try {
+    form.steps = JSON.parse(form.steps);
+    form.end_screen = JSON.parse(form.end_screen);
+    form.theme = JSON.parse(form.theme);
+  } catch {
+    return res.status(500).json({ error: 'Failed to read created form' });
+  }
   res.status(201).json({ form });
 });
 
@@ -87,9 +95,13 @@ router.put('/:id', (req, res) => {
   );
 
   const form = db.prepare('SELECT * FROM forms WHERE id = ?').get(req.params.id);
-  form.steps = JSON.parse(form.steps);
-  form.end_screen = JSON.parse(form.end_screen);
-  form.theme = JSON.parse(form.theme);
+  try {
+    form.steps = JSON.parse(form.steps);
+    form.end_screen = JSON.parse(form.end_screen);
+    form.theme = JSON.parse(form.theme);
+  } catch {
+    return res.status(500).json({ error: 'Form data is corrupted' });
+  }
   res.json({ form });
 });
 
@@ -98,10 +110,13 @@ router.delete('/:id', (req, res) => {
   const db = getDb();
   const existing = db.prepare('SELECT id FROM forms WHERE id = ? AND user_id = ?').get(req.params.id, req.userId);
   if (!existing) return res.status(404).json({ error: 'Form not found' });
-  db.prepare('DELETE FROM analytics_events WHERE form_id = ?').run(req.params.id);
-  db.prepare('DELETE FROM integrations WHERE form_id = ?').run(req.params.id);
-  db.prepare('DELETE FROM submissions WHERE form_id = ?').run(req.params.id);
-  db.prepare('DELETE FROM forms WHERE id = ?').run(req.params.id);
+  const deleteForm = db.transaction((formId) => {
+    db.prepare('DELETE FROM analytics_events WHERE form_id = ?').run(formId);
+    db.prepare('DELETE FROM integrations WHERE form_id = ?').run(formId);
+    db.prepare('DELETE FROM submissions WHERE form_id = ?').run(formId);
+    db.prepare('DELETE FROM forms WHERE id = ?').run(formId);
+  });
+  deleteForm(req.params.id);
   res.json({ ok: true });
 });
 

--- a/backend/src/routes/integrations.js
+++ b/backend/src/routes/integrations.js
@@ -13,7 +13,9 @@ router.get('/:formId', (req, res) => {
   if (!form) return res.status(404).json({ error: 'Form not found' });
 
   const integrations = db.prepare('SELECT * FROM integrations WHERE form_id = ? ORDER BY created_at DESC').all(req.params.formId);
-  integrations.forEach(i => { i.config = JSON.parse(i.config); });
+  integrations.forEach(i => {
+    try { i.config = JSON.parse(i.config); } catch { i.config = {}; }
+  });
   res.json({ integrations });
 });
 

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -14,16 +14,20 @@ router.get('/form/:slug', (req, res) => {
 
   if (!form) return res.status(404).json({ error: 'Form not found' });
 
-  form.steps = JSON.parse(form.steps);
-  form.end_screen = JSON.parse(form.end_screen);
-  form.theme = JSON.parse(form.theme);
+  try {
+    form.steps = JSON.parse(form.steps);
+    form.end_screen = JSON.parse(form.end_screen);
+    form.theme = JSON.parse(form.theme);
+  } catch {
+    return res.status(500).json({ error: 'Form data is corrupted' });
+  }
   res.json({ form });
 });
 
 // Submit form response (public)
 router.post('/form/:slug/submit', async (req, res) => {
   // Rate limit: 10 submissions per IP per minute
-  const ip = req.ip || req.connection.remoteAddress;
+  const ip = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.ip || req.socket?.remoteAddress;
   const allowed = checkRateLimit(`submit:${ip}`, 10, 60);
   if (!allowed) {
     return res.status(429).json({ error: 'Too many submissions, please try again later' });
@@ -69,7 +73,7 @@ router.post('/form/:slug/submit', async (req, res) => {
 
 // Track analytics event (public, rate limited)
 router.post('/track', (req, res) => {
-  const ip = req.ip || req.connection.remoteAddress;
+  const ip = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.ip || req.socket?.remoteAddress;
   const allowed = checkRateLimit(`track:${ip}`, 100, 60);
   if (!allowed) return res.status(429).json({ error: 'Rate limited' });
 
@@ -80,11 +84,16 @@ router.post('/track', (req, res) => {
   if (!validEvents.includes(event)) return res.status(400).json({ error: 'Invalid event type' });
 
   const db = getDb();
+  const formExists = db.prepare('SELECT id FROM forms WHERE id = ?').get(formId);
+  if (!formExists) return res.status(404).json({ error: 'Form not found' });
+
   try {
     db.prepare(
       'INSERT INTO analytics_events (form_id, event, session_id, step_index, step_id) VALUES (?, ?, ?, ?, ?)'
     ).run(formId, event, sessionId || null, stepIndex ?? null, stepId || null);
-  } catch {}
+  } catch (err) {
+    console.error('Analytics event insert failed:', err.message);
+  }
 
   res.json({ ok: true });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "1.0.0",
+  "version": "0.7.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -7,8 +7,8 @@ async function request(path, options = {}) {
     ...options,
   });
   if (res.status === 401 && !path.includes('/auth/')) {
-    window.location.href = '/login';
-    return;
+    window.location.replace('/login');
+    throw new Error('Session expired');
   }
   const text = await res.text();
   if (!text) {

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -67,6 +67,9 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   const [direction, setDirection] = useState('forward');
   const containerRef = useRef(null);
   const trackedRef = useRef(false);
+  // Always-current ref so auto-advance timer can check if user navigated away
+  const currentStepRef = useRef(currentStep);
+  useEffect(() => { currentStepRef.current = currentStep; }, [currentStep]);
 
   const allSteps = form.steps || [];
   const theme = form.theme || {};
@@ -231,12 +234,18 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
   const AUTO_ADVANCE_FIELDS = ['select', 'multi-select', 'yes-no', 'rating', 'image-select'];
 
-  // Auto-advance for choice-based field types when answer is provided
+  // Auto-advance for choice-based field types when answer is provided.
+  // Capture the step index at schedule time and compare against the ref at
+  // fire time so we don't advance if the user has already navigated away.
   useEffect(() => {
     if (step && answers[step.id] !== undefined && !theme?.disableAutoAdvance && AUTO_ADVANCE_FIELDS.includes(step.type)) {
-      const timer = setTimeout(() => next(), 400);
+      const stepAtSchedule = currentStep;
+      const timer = setTimeout(() => {
+        if (currentStepRef.current === stepAtSchedule) next();
+      }, 400);
       return () => clearTimeout(timer);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [answers[step?.id]]);
 
   if (submitted) {

--- a/frontend/src/components/IntegrationsPanel.jsx
+++ b/frontend/src/components/IntegrationsPanel.jsx
@@ -13,12 +13,18 @@ export default function IntegrationsPanel({ formId }) {
   const [adding, setAdding] = useState(null);
   const [testing, setTesting] = useState(null);
   const [testResult, setTestResult] = useState(null);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    api.getIntegrations(formId).then(d => setIntegrations(d.integrations));
+    api.getIntegrations(formId)
+      .then(d => setIntegrations(d.integrations))
+      .catch(err => setError(err.message || 'Failed to load integrations'));
   }, [formId]);
 
   async function addIntegration(type) {
+    if (adding) return;
+    setAdding(type);
+    setError('');
     const actualType = type === 'google_sheets_sa' ? 'google_sheets' : type;
     const defaults = {
       webhook: { url: '', secret: '', method: 'POST' },
@@ -26,20 +32,33 @@ export default function IntegrationsPanel({ formId }) {
       google_sheets: { mode: 'apps_script', apps_script_url: '' },
       google_sheets_sa: { mode: 'service_account', credentials_json: '', spreadsheet_id: '', sheet_name: 'Sheet1' },
     };
-    const { integration } = await api.createIntegration(formId, { type: actualType, config: defaults[type] || defaults[actualType] });
-    setIntegrations([integration, ...integrations]);
-    setAdding(null);
+    try {
+      const { integration } = await api.createIntegration(formId, { type: actualType, config: defaults[type] || defaults[actualType] });
+      setIntegrations(prev => [integration, ...prev]);
+    } catch (err) {
+      setError(err.message || 'Failed to add integration');
+    } finally {
+      setAdding(null);
+    }
   }
 
   async function updateIntegration(id, updates) {
-    const { integration } = await api.updateIntegration(formId, id, updates);
-    setIntegrations(integrations.map(i => i.id === id ? integration : i));
+    try {
+      const { integration } = await api.updateIntegration(formId, id, updates);
+      setIntegrations(prev => prev.map(i => i.id === id ? integration : i));
+    } catch (err) {
+      setError(err.message || 'Failed to update integration');
+    }
   }
 
   async function deleteIntegration(id) {
     if (!confirm('Delete this integration?')) return;
-    await api.deleteIntegration(formId, id);
-    setIntegrations(integrations.filter(i => i.id !== id));
+    try {
+      await api.deleteIntegration(formId, id);
+      setIntegrations(prev => prev.filter(i => i.id !== id));
+    } catch (err) {
+      setError(err.message || 'Failed to delete integration');
+    }
   }
 
   async function testIntegration(id) {
@@ -47,11 +66,13 @@ export default function IntegrationsPanel({ formId }) {
     setTestResult(null);
     try {
       const result = await api.testIntegration(formId, id);
-      setTestResult({ id, ok: result.results?.[0]?.ok, error: result.results?.[0]?.error });
+      const first = result.results?.[0];
+      setTestResult({ id, ok: first?.ok ?? false, error: first?.error });
     } catch (err) {
       setTestResult({ id, ok: false, error: err.message });
+    } finally {
+      setTesting(null);
     }
-    setTesting(null);
   }
 
   function updateConfig(id, key, value) {
@@ -63,16 +84,25 @@ export default function IntegrationsPanel({ formId }) {
 
   return (
     <div>
-      {/* Add new integration */}
-      {!adding ? (
-        <div style={{ display: 'flex', gap: 8, marginBottom: 24 }}>
-          {INTEGRATION_TYPES.map(t => (
-            <button key={t.value} className="btn btn-secondary" onClick={() => addIntegration(t.value)}>
-              <span>{t.icon}</span> Add {t.label}
-            </button>
-          ))}
+      {error && (
+        <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
+          {error}
         </div>
-      ) : null}
+      )}
+
+      {/* Add new integration */}
+      <div style={{ display: 'flex', gap: 8, marginBottom: 24, flexWrap: 'wrap' }}>
+        {INTEGRATION_TYPES.map(t => (
+          <button
+            key={t.value}
+            className="btn btn-secondary"
+            onClick={() => addIntegration(t.value)}
+            disabled={adding !== null}
+          >
+            <span>{t.icon}</span> {adding === t.value ? 'Adding...' : `Add ${t.label}`}
+          </button>
+        ))}
+      </div>
 
       {integrations.length === 0 && (
         <div className="card" style={{ textAlign: 'center', padding: 48 }}>
@@ -117,7 +147,7 @@ export default function IntegrationsPanel({ formId }) {
               background: testResult.ok ? '#E8F8F5' : '#FDEDEC',
               color: testResult.ok ? '#00B894' : '#E17055',
             }}>
-              {testResult.ok ? 'Test successful!' : `Test failed: ${testResult.error}`}
+              {testResult.ok ? 'Test successful!' : `Test failed: ${testResult.error || 'Unknown error'}`}
             </div>
           )}
 

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -8,17 +8,22 @@ export default function Analytics() {
   const [detail, setDetail] = useState(null);
   const [days, setDays] = useState(30);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    api.getAnalyticsOverview(days).then(d => {
-      setForms(d.forms);
-      setLoading(false);
-    });
+    setLoading(true);
+    setError('');
+    api.getAnalyticsOverview(days)
+      .then(d => setForms(d.forms))
+      .catch(err => setError(err.message || 'Failed to load analytics'))
+      .finally(() => setLoading(false));
   }, [days]);
 
   useEffect(() => {
     if (selected) {
-      api.getAnalyticsDetail(selected, days).then(d => setDetail(d));
+      api.getAnalyticsDetail(selected, days)
+        .then(d => setDetail(d))
+        .catch(() => setDetail(null));
     } else {
       setDetail(null);
     }
@@ -36,6 +41,12 @@ export default function Analytics() {
           <option value={90}>Last 90 days</option>
         </select>
       </div>
+
+      {error && (
+        <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
+          {error}
+        </div>
+      )}
 
       {/* Overview cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 16, marginBottom: 24 }}>
@@ -68,7 +79,7 @@ export default function Analytics() {
         ))}
       </div>
 
-      {forms.length === 0 && (
+      {forms.length === 0 && !error && (
         <div className="card" style={{ textAlign: 'center', padding: 60 }}>
           <h3>No analytics data yet</h3>
           <p style={{ color: '#636E72' }}>Publish a form and share it to start collecting analytics.</p>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -4,23 +4,32 @@ import { api } from '../api';
 
 export default function Dashboard() {
   const [forms, setForms] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
   const navigate = useNavigate();
 
   useEffect(() => {
-    api.getForms().then(d => setForms(d.forms));
+    api.getForms()
+      .then(d => setForms(d.forms))
+      .catch(err => setError(err.message || 'Failed to load forms'))
+      .finally(() => setLoading(false));
   }, []);
 
   async function createForm() {
-    const { form } = await api.createForm({
-      title: 'New Form',
-      steps: [
-        { id: 'name', type: 'text', question: 'What is your name?', label: 'Name', required: true, placeholder: 'First and last name' },
-        { id: 'email', type: 'email', question: 'What is your email address?', label: 'Email', required: true },
-        { id: 'interest', type: 'select', question: 'What are you interested in?', label: 'Interest', required: true, options: ['Product A', 'Product B', 'Consulting', 'Other'] },
-      ],
-      end_screen: { title: 'Thank you!', message: 'We will get back to you shortly.' },
-    });
-    navigate(`/forms/${form.id}`);
+    try {
+      const { form } = await api.createForm({
+        title: 'New Form',
+        steps: [
+          { id: 'name', type: 'text', question: 'What is your name?', label: 'Name', required: true, placeholder: 'First and last name' },
+          { id: 'email', type: 'email', question: 'What is your email address?', label: 'Email', required: true },
+          { id: 'interest', type: 'select', question: 'What are you interested in?', label: 'Interest', required: true, options: ['Product A', 'Product B', 'Consulting', 'Other'] },
+        ],
+        end_screen: { title: 'Thank you!', message: 'We will get back to you shortly.' },
+      });
+      navigate(`/forms/${form.id}`);
+    } catch (err) {
+      setError(err.message || 'Failed to create form');
+    }
   }
 
   async function deleteForm(id) {
@@ -35,9 +44,15 @@ export default function Dashboard() {
     } else {
       if (!confirm('Are you sure you want to delete this form?')) return;
     }
-    await api.deleteForm(id);
-    setForms(forms.filter(f => f.id !== id));
+    try {
+      await api.deleteForm(id);
+      setForms(forms.filter(f => f.id !== id));
+    } catch (err) {
+      setError(err.message || 'Failed to delete form');
+    }
   }
+
+  if (loading) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
 
   return (
     <div>
@@ -45,6 +60,12 @@ export default function Dashboard() {
         <h2>Forms</h2>
         <button className="btn btn-primary" onClick={createForm}>+ New Form</button>
       </div>
+
+      {error && (
+        <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
+          {error}
+        </div>
+      )}
 
       {forms.length === 0 ? (
         <div className="card" style={{ textAlign: 'center', padding: 60 }}>

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -40,20 +40,31 @@ const EMOJI_CATEGORIES = {
 export default function FormEditor() {
   const { id } = useParams();
   const [form, setForm] = useState(null);
+  const [loadError, setLoadError] = useState('');
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState('');
   const [activeTab, setActiveTab] = useState('steps');
   const [expandedStep, setExpandedStep] = useState(null);
 
   useEffect(() => {
-    api.getForm(id).then(d => setForm(d.form));
+    setLoadError('');
+    api.getForm(id)
+      .then(d => setForm(d.form))
+      .catch(err => setLoadError(err.message || 'Failed to load form'));
   }, [id]);
 
+  if (loadError) return (
+    <div style={{ padding: 40, textAlign: 'center', color: '#E17055' }}>
+      <p>{loadError}</p>
+    </div>
+  );
   if (!form) return <div>Loading...</div>;
 
   async function save(updates = {}) {
     setSaving(true);
     setSaved(false);
+    setSaveError('');
     const payload = {
       title: form.title,
       steps: form.steps,
@@ -63,11 +74,16 @@ export default function FormEditor() {
       published: form.published,
       ...updates,
     };
-    const { form: updated } = await api.updateForm(id, payload);
-    setForm(updated);
-    setSaving(false);
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    try {
+      const { form: updated } = await api.updateForm(id, payload);
+      setForm(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setSaveError(err.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
   }
 
   function updateStep(index, changes) {
@@ -148,6 +164,7 @@ export default function FormEditor() {
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           {saved && <span style={{ color: '#00B894', fontSize: 13 }}>Saved!</span>}
+          {saveError && <span style={{ color: '#E17055', fontSize: 13 }}>{saveError}</span>}
           {form.published ? (
             <a
               href={`${baseUrl}/embed/${form.slug}`}

--- a/frontend/src/pages/Submissions.jsx
+++ b/frontend/src/pages/Submissions.jsx
@@ -20,21 +20,26 @@ export default function Submissions() {
   const [submissions, setSubmissions] = useState([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    api.getForm(id).then(d => setForm(d.form));
+    api.getForm(id)
+      .then(d => setForm(d.form))
+      .catch(err => setError(err.message || 'Failed to load form'));
   }, [id]);
 
   useEffect(() => {
-    api.getSubmissions(id, page).then(d => {
-      setSubmissions(d.submissions);
-      setTotal(d.total);
-    });
+    api.getSubmissions(id, page)
+      .then(d => {
+        setSubmissions(d.submissions);
+        setTotal(d.total);
+      })
+      .catch(err => setError(err.message || 'Failed to load submissions'));
   }, [id, page]);
 
-  if (!form) return <div>Loading...</div>;
+  if (!form && !error) return <div>Loading...</div>;
 
-  const steps = form.steps || [];
+  const steps = form?.steps || [];
   const totalPages = Math.ceil(total / 20);
 
   return (
@@ -42,13 +47,19 @@ export default function Submissions() {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
         <div>
           <Link to={`/forms/${id}`} style={{ color: '#636E72', textDecoration: 'none', fontSize: 13 }}>&larr; Back to form</Link>
-          <h2 style={{ marginTop: 8 }}>Responses: {form.title}</h2>
+          <h2 style={{ marginTop: 8 }}>Responses: {form?.title}</h2>
           <p style={{ color: '#636E72', fontSize: 14 }}>{total} entries</p>
         </div>
         <a href={api.exportSubmissions(id)} className="btn btn-secondary" style={{ textDecoration: 'none' }}>
           Export CSV
         </a>
       </div>
+
+      {error && (
+        <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
+          {error}
+        </div>
+      )}
 
       {submissions.length === 0 ? (
         <div className="card" style={{ textAlign: 'center', padding: 60 }}>


### PR DESCRIPTION
## Summary

- **SECURITY:** `DELETE /users/:id` was missing `requireAdmin` middleware — any authenticated user could delete any account. Fixed.
- **SECURITY:** Server now warns at startup when `JWT_SECRET` is not set in the environment.
- **Backend reliability:** All `JSON.parse()` calls on DB-stored form fields are now wrapped in try/catch; corrupted records return a proper 500 instead of crashing the handler.
- **Backend:** `/api/public/track` now validates `formId` existence before inserting analytics events, preventing orphaned rows.
- **Backend:** Cascaded form deletion (analytics → integrations → submissions → form) now runs inside a single SQLite transaction.
- **Backend:** Rate limiters now read `X-Forwarded-For` first so they work correctly behind reverse proxies.
- **Backend:** Analytics insert errors are now logged instead of silently swallowed.
- **Frontend:** `api.js` now throws after a 401 redirect so callers don't continue executing with a stale session.
- **Frontend:** Dashboard, Analytics, FormEditor, Submissions, and IntegrationsPanel all show error messages when API calls fail instead of leaving the user on a blank/loading screen.
- **Frontend:** "Add integration" buttons are disabled while a creation request is in flight (prevents duplicate integrations on double-click).
- **Frontend:** Fixed a stale-closure bug in `FormRenderer` where the 400 ms auto-advance timer could fire after the user had already navigated to a different step.

## Test plan

- [ ] Log in as a non-admin user; confirm `DELETE /auth/users/:id` returns 403
- [ ] Start the server without `JWT_SECRET` set; confirm warning appears in logs
- [ ] Delete a form with submissions/integrations/analytics; confirm all related rows are gone
- [ ] Submit a form behind a reverse proxy (or with `X-Forwarded-For` header); confirm rate limiting triggers correctly
- [ ] Simulate a network error on the Dashboard; confirm an error message appears instead of a blank screen
- [ ] Add two integrations rapidly (double-click); confirm only one is created
- [ ] On a Single Choice / Rating step, select an answer then immediately click Back; confirm the form does not skip ahead an extra step

https://claude.ai/code/session_01YJnQ1P1czxF82KEdMmrMnY