### PR TITLE
feat: animated bg live preview, GTM cookie consent banner, submission delete fix (v0.7.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.7.6] - 2026-04-16
+
+### Added
+- **GTM Cookie Consent Banner** — When a GTM Container ID is configured, admins can now enable a cookie/tracking consent banner in the GTM / GDPR tab. GTM is only injected after the visitor accepts. All banner texts are fully editable per form: message, Accept button label, and Decline button label. Consent is persisted in localStorage so the banner doesn't reappear.
+- **Live Theme Preview in Design tab** — The Design tab now shows a live preview panel that immediately reflects color and animated-background changes without needing to save or open the published form. This makes it easy to verify that animations are configured and working before publishing.
+
+### Fixed
+- **Backend: submissions DELETE returns 404** — `DELETE /submissions/:formId/:submissionId` previously returned `200 { ok: true }` even when the submission ID did not exist. It now returns `404 { error: "Submission not found" }` when no row was deleted.
+
 ## [0.7.5] - 2026-04-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.7.5
+# 🌊 OpenFlow v0.7.6
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -39,7 +39,7 @@ app.get('*', (req, res) => {
   if (fs.existsSync(indexPath)) {
     res.sendFile(indexPath);
   } else {
-    res.status(200).json({ status: 'OpenFlow API running', version: '0.7.5' });
+    res.status(200).json({ status: 'OpenFlow API running', version: '0.7.6' });
   }
 });
 

--- a/backend/src/routes/submissions.js
+++ b/backend/src/routes/submissions.js
@@ -61,7 +61,8 @@ router.delete('/:formId/:submissionId', (req, res) => {
   const db = getDb();
   const form = db.prepare('SELECT id FROM forms WHERE id = ? AND user_id = ?').get(req.params.formId, req.userId);
   if (!form) return res.status(404).json({ error: 'Form not found' });
-  db.prepare('DELETE FROM submissions WHERE id = ? AND form_id = ?').run(req.params.submissionId, req.params.formId);
+  const result = db.prepare('DELETE FROM submissions WHERE id = ? AND form_id = ?').run(req.params.submissionId, req.params.formId);
+  if (result.changes === 0) return res.status(404).json({ error: 'Submission not found' });
   res.json({ ok: true });
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,7 +8,7 @@ import Submissions from './pages/Submissions';
 import Users from './pages/Users';
 import Analytics from './pages/Analytics';
 
-const APP_VERSION = '0.7.4';
+const APP_VERSION = '0.7.6';
 
 function getInitialTheme() {
   return localStorage.getItem('of_theme') || 'auto';

--- a/frontend/src/pages/EmbedView.jsx
+++ b/frontend/src/pages/EmbedView.jsx
@@ -3,10 +3,51 @@ import { useParams } from 'react-router-dom';
 import FormRenderer from '../components/FormRenderer';
 import { api } from '../api';
 
+function CookieBanner({ form, onAccept, onDecline }) {
+  const es = form.end_screen || {};
+  const text = es.cookieConsentText || 'We use Google Tag Manager to analyze form interactions and improve your experience. Do you accept?';
+  const acceptLabel = es.cookieConsentAcceptLabel || 'Accept';
+  const declineLabel = es.cookieConsentDeclineLabel || 'Decline';
+  const primary = form.theme?.primaryColor || '#6C5CE7';
+
+  return (
+    <div style={{
+      position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 9999,
+      background: '#fff', borderTop: '1px solid #e0e0e0',
+      boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
+      padding: '16px 24px',
+      display: 'flex', flexDirection: 'column', gap: 12,
+    }}>
+      <p style={{ margin: 0, fontSize: 14, color: '#2D3436', lineHeight: 1.5 }}>{text}</p>
+      <div style={{ display: 'flex', gap: 10 }}>
+        <button
+          onClick={onAccept}
+          style={{
+            background: primary, color: '#fff', border: 'none',
+            padding: '9px 20px', borderRadius: 8, fontSize: 14, fontWeight: 600, cursor: 'pointer',
+          }}
+        >
+          {acceptLabel}
+        </button>
+        <button
+          onClick={onDecline}
+          style={{
+            background: 'none', color: '#636E72', border: '1px solid #ccc',
+            padding: '9px 20px', borderRadius: 8, fontSize: 14, cursor: 'pointer',
+          }}
+        >
+          {declineLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function EmbedView() {
   const { slug } = useParams();
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
+  const [cookieConsent, setCookieConsent] = useState(null);
 
   // Force light theme on embedded form pages (dark mode is admin-only)
   useEffect(() => {
@@ -23,20 +64,40 @@ export default function EmbedView() {
     api.getPublicForm(slug).then(d => setForm(d.form)).catch(e => setError(e.message));
   }, [slug]);
 
+  // Determine cookie consent state once form is loaded
   useEffect(() => {
-    if (form?.gtm_id) {
-      const script = document.createElement('script');
-      script.innerHTML = `
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','${form.gtm_id}');
-      `;
-      document.head.appendChild(script);
-      return () => document.head.removeChild(script);
-    }
-  }, [form?.gtm_id]);
+    if (!form) return;
+    if (!form.gtm_id) { setCookieConsent(null); return; }
+    if (!form.end_screen?.cookieConsentEnabled) { setCookieConsent(true); return; }
+    const stored = localStorage.getItem(`of_cc_${form.id}`);
+    if (stored === 'accepted') { setCookieConsent(true); }
+    else if (stored === 'declined') { setCookieConsent(false); }
+    else { setCookieConsent('pending'); }
+  }, [form]);
+
+  // Inject GTM only when consent is given
+  useEffect(() => {
+    if (!form?.gtm_id || cookieConsent !== true) return;
+    const script = document.createElement('script');
+    script.innerHTML = `
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','${form.gtm_id}');
+    `;
+    document.head.appendChild(script);
+    return () => { if (document.head.contains(script)) document.head.removeChild(script); };
+  }, [form?.gtm_id, cookieConsent]);
+
+  function handleAccept() {
+    localStorage.setItem(`of_cc_${form.id}`, 'accepted');
+    setCookieConsent(true);
+  }
+  function handleDecline() {
+    localStorage.setItem(`of_cc_${form.id}`, 'declined');
+    setCookieConsent(false);
+  }
 
   // Notify parent iframe of height changes for auto-resize
   useEffect(() => {
@@ -53,5 +114,12 @@ export default function EmbedView() {
   if (error) return <div style={{ padding: 40, textAlign: 'center' }}>Form not found</div>;
   if (!form) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
 
-  return <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data)} embedded />;
+  return (
+    <>
+      <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data)} embedded />
+      {cookieConsent === 'pending' && (
+        <CookieBanner form={form} onAccept={handleAccept} onDecline={handleDecline} />
+      )}
+    </>
+  );
 }

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { api } from '../api';
 import IntegrationsPanel from '../components/IntegrationsPanel';
+import '../components/FormRenderer.css';
 
 // Field types sorted logically: question types first, then contact/data fields
 const FIELD_TYPES = [
@@ -24,6 +25,19 @@ const FIELD_TYPES = [
 ];
 
 const FIELD_TYPE_MAP = Object.fromEntries(FIELD_TYPES.map(f => [f.value, f]));
+
+// Lighten a hex color by amount (0-255) — mirrors the same helper in FormRenderer
+function adjustColor(hex, amount) {
+  const clean = hex.replace('#', '');
+  if (clean.length !== 6) return hex;
+  const num = parseInt(clean, 16);
+  const r = Math.min(255, (num >> 16) + amount);
+  const g = Math.min(255, ((num >> 8) & 0x00ff) + amount);
+  const b = Math.min(255, (num & 0x0000ff) + amount);
+  return `#${(1 << 24 | r << 16 | g << 8 | b).toString(16).slice(1)}`;
+}
+
+const BG_SHAPE_COUNTS = { waves: 3, bubbles: 4, aurora: 3, particles: 6, flow: 4 };
 
 // Common emoji categories for the icon picker
 const EMOJI_CATEGORIES = {
@@ -252,6 +266,18 @@ export default function FormEditor() {
       {/* Theme Tab */}
       {activeTab === 'theme' && (
         <div>
+          {/* Live Preview */}
+          <div className="card">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+              <span style={{ fontSize: 20 }}>👁️</span>
+              <div>
+                <h3 style={{ margin: 0 }}>Live Preview</h3>
+                <p style={{ color: 'var(--text-light)', fontSize: 13, margin: 0 }}>Reflects unsaved changes — click <strong>Save</strong> to publish.</p>
+              </div>
+            </div>
+            <ThemePreview theme={form.theme || {}} />
+          </div>
+
           {/* Colors */}
           <div className="card">
             <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
@@ -532,7 +558,7 @@ export default function FormEditor() {
 
           {/* GDPR Consent */}
           <div className="card">
-            <h3 style={{ marginBottom: 4 }}>GDPR / Consent</h3>
+            <h3 style={{ marginBottom: 4 }}>GDPR / Submission Consent</h3>
             <p style={{ color: '#636E72', fontSize: 13, marginBottom: 16 }}>
               When enabled, a consent checkbox is automatically shown on the last step of the form before submission.
             </p>
@@ -555,6 +581,60 @@ export default function FormEditor() {
                   onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, consentText: e.target.value } })}
                   placeholder="I agree to the privacy policy and terms of service."
                 />
+              </div>
+            )}
+          </div>
+
+          {/* Cookie / Tracking Consent Banner */}
+          <div className="card">
+            <h3 style={{ marginBottom: 4 }}>Cookie / Tracking Consent Banner</h3>
+            <p style={{ color: '#636E72', fontSize: 13, marginBottom: 16 }}>
+              When enabled, a cookie banner is shown to visitors <strong>before</strong> Google Tag Manager is loaded.
+              GTM only fires after the visitor accepts. Consent is stored in the browser so the banner does not re-appear on subsequent visits.
+            </p>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 15, fontWeight: 600, marginBottom: 16, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={!!form.end_screen?.cookieConsentEnabled}
+                onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, cookieConsentEnabled: e.target.checked } })}
+                style={{ width: 20, height: 20, accentColor: 'var(--primary)' }}
+                disabled={!form.gtm_id}
+              />
+              Show cookie consent banner before loading GTM
+            </label>
+            {!form.gtm_id && (
+              <p style={{ fontSize: 13, color: '#E17055', marginBottom: 8 }}>A GTM Container ID must be set above to use this feature.</p>
+            )}
+            {form.end_screen?.cookieConsentEnabled && (
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+                <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+                  <label>Banner Message</label>
+                  <textarea
+                    className="input"
+                    rows={3}
+                    value={form.end_screen?.cookieConsentText || 'We use Google Tag Manager to analyze form interactions and improve your experience. Do you accept?'}
+                    onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, cookieConsentText: e.target.value } })}
+                    placeholder="We use Google Tag Manager to analyze form interactions…"
+                  />
+                </div>
+                <div className="input-group">
+                  <label>Accept Button Label</label>
+                  <input
+                    className="input"
+                    value={form.end_screen?.cookieConsentAcceptLabel || 'Accept'}
+                    onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, cookieConsentAcceptLabel: e.target.value } })}
+                    placeholder="Accept"
+                  />
+                </div>
+                <div className="input-group">
+                  <label>Decline Button Label</label>
+                  <input
+                    className="input"
+                    value={form.end_screen?.cookieConsentDeclineLabel || 'Decline'}
+                    onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, cookieConsentDeclineLabel: e.target.value } })}
+                    placeholder="Decline"
+                  />
+                </div>
               </div>
             )}
           </div>
@@ -1094,6 +1174,62 @@ function EmojiPicker({ activeCategory, onCategoryChange, onSelect, onClose }) {
           </button>
         ))}
       </div>
+    </div>
+  );
+}
+
+/* ===========================
+   ThemePreview - Animated background live preview
+   =========================== */
+function ThemePreview({ theme }) {
+  const bgAnimation = theme.backgroundAnimation || 'none';
+  const primaryColor = theme.primaryColor || '#6C5CE7';
+  const accentColor = theme.accentColor || adjustColor(primaryColor, 40);
+  const bgColor = theme.backgroundColor || '#FFFFFF';
+  const textColor = theme.textColor || '#2D3436';
+
+  const cssVars = {
+    '--form-primary': primaryColor,
+    '--form-bg': bgColor,
+    '--form-text': textColor,
+    '--form-bg-accent': accentColor,
+  };
+
+  return (
+    <div style={{
+      position: 'relative',
+      height: 200,
+      borderRadius: 12,
+      overflow: 'hidden',
+      border: '1px solid var(--border)',
+      background: bgColor,
+      ...cssVars,
+    }}>
+      {/* Animated background shapes */}
+      {bgAnimation !== 'none' && BG_SHAPE_COUNTS[bgAnimation] && (
+        <div className={`form-bg-animation bg-${bgAnimation}`}>
+          {Array.from({ length: BG_SHAPE_COUNTS[bgAnimation] }, (_, i) => <span key={i} />)}
+        </div>
+      )}
+      {/* Placeholder form content */}
+      <div style={{ position: 'relative', zIndex: 1, padding: '28px 32px', color: textColor, fontFamily: theme.fontFamily || 'inherit' }}>
+        <div style={{ fontSize: 11, fontWeight: 700, color: primaryColor, textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 10, opacity: 0.8 }}>
+          1 / 3
+        </div>
+        <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 20 }}>How does your form look?</div>
+        <button style={{
+          background: primaryColor, color: '#fff',
+          border: 'none', padding: '10px 22px',
+          borderRadius: 8, fontSize: 14, fontWeight: 600, cursor: 'default',
+        }}>
+          Next →
+        </button>
+      </div>
+      {bgAnimation === 'none' && (
+        <div style={{ position: 'absolute', bottom: 10, right: 14, fontSize: 12, color: textColor, opacity: 0.35 }}>
+          No animation selected
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/FormView.jsx
+++ b/frontend/src/pages/FormView.jsx
@@ -3,10 +3,52 @@ import { useParams } from 'react-router-dom';
 import FormRenderer from '../components/FormRenderer';
 import { api } from '../api';
 
+function CookieBanner({ form, onAccept, onDecline }) {
+  const es = form.end_screen || {};
+  const text = es.cookieConsentText || 'We use Google Tag Manager to analyze form interactions and improve your experience. Do you accept?';
+  const acceptLabel = es.cookieConsentAcceptLabel || 'Accept';
+  const declineLabel = es.cookieConsentDeclineLabel || 'Decline';
+  const primary = form.theme?.primaryColor || '#6C5CE7';
+
+  return (
+    <div style={{
+      position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 9999,
+      background: '#fff', borderTop: '1px solid #e0e0e0',
+      boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
+      padding: '16px 24px',
+      display: 'flex', flexDirection: 'column', gap: 12,
+    }}>
+      <p style={{ margin: 0, fontSize: 14, color: '#2D3436', lineHeight: 1.5 }}>{text}</p>
+      <div style={{ display: 'flex', gap: 10 }}>
+        <button
+          onClick={onAccept}
+          style={{
+            background: primary, color: '#fff', border: 'none',
+            padding: '9px 20px', borderRadius: 8, fontSize: 14, fontWeight: 600, cursor: 'pointer',
+          }}
+        >
+          {acceptLabel}
+        </button>
+        <button
+          onClick={onDecline}
+          style={{
+            background: 'none', color: '#636E72', border: '1px solid #ccc',
+            padding: '9px 20px', borderRadius: 8, fontSize: 14, cursor: 'pointer',
+          }}
+        >
+          {declineLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function FormView() {
   const { slug } = useParams();
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
+  // null = not yet determined, true = accepted, false = declined, 'pending' = needs banner
+  const [cookieConsent, setCookieConsent] = useState(null);
 
   // Force light theme on public form pages (dark mode is admin-only)
   useEffect(() => {
@@ -23,24 +65,50 @@ export default function FormView() {
     api.getPublicForm(slug).then(d => setForm(d.form)).catch(e => setError(e.message));
   }, [slug]);
 
+  // Determine cookie consent state once form is loaded
   useEffect(() => {
-    if (form?.gtm_id) {
-      // Inject GTM
-      const script = document.createElement('script');
-      script.innerHTML = `
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','${form.gtm_id}');
-      `;
-      document.head.appendChild(script);
-      return () => document.head.removeChild(script);
-    }
-  }, [form?.gtm_id]);
+    if (!form) return;
+    if (!form.gtm_id) { setCookieConsent(null); return; }
+    if (!form.end_screen?.cookieConsentEnabled) { setCookieConsent(true); return; }
+    const stored = localStorage.getItem(`of_cc_${form.id}`);
+    if (stored === 'accepted') { setCookieConsent(true); }
+    else if (stored === 'declined') { setCookieConsent(false); }
+    else { setCookieConsent('pending'); }
+  }, [form]);
+
+  // Inject GTM only when consent is given
+  useEffect(() => {
+    if (!form?.gtm_id || cookieConsent !== true) return;
+    const script = document.createElement('script');
+    script.innerHTML = `
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','${form.gtm_id}');
+    `;
+    document.head.appendChild(script);
+    return () => { if (document.head.contains(script)) document.head.removeChild(script); };
+  }, [form?.gtm_id, cookieConsent]);
+
+  function handleAccept() {
+    localStorage.setItem(`of_cc_${form.id}`, 'accepted');
+    setCookieConsent(true);
+  }
+  function handleDecline() {
+    localStorage.setItem(`of_cc_${form.id}`, 'declined');
+    setCookieConsent(false);
+  }
 
   if (error) return <div style={{ padding: 40, textAlign: 'center' }}><h2>Form not found</h2></div>;
   if (!form) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
 
-  return <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data)} />;
+  return (
+    <>
+      <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data)} />
+      {cookieConsent === 'pending' && (
+        <CookieBanner form={form} onAccept={handleAccept} onDecline={handleDecline} />
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

- **Animated background live preview** — the Design tab now renders a live preview panel that immediately reflects color and animation changes without saving or publishing first. This directly addresses the user reports of animations "not working" — the root cause was no feedback in the editor: changes weren't visible until the form was saved, published, and opened in a new tab.
- **GTM Cookie Consent Banner** — GDPR-friendly opt-in: GTM only loads after the visitor accepts the banner. Fully configurable per form (message text, Accept/Decline button labels). Consent persisted in `localStorage`.
- **Fix: submission DELETE now returns 404** when the submission doesn't exist, instead of silently returning `200`.

## How the cookie consent banner works

1. Admin opens **GTM / GDPR** tab → sets a GTM Container ID
2. Checks **"Show cookie consent banner before loading GTM"**
3. Edits the message text, Accept button label, and Decline button label
4. Saves the form

Visitors see the banner at the bottom of the form. If they accept, GTM fires and consent is stored in `localStorage` (`of_cc_<formId>`) so the banner does not reappear. If they decline, GTM is never loaded for that session (or until they clear storage).

## Test plan

- [ ] Open Design tab → change Primary Color and Background Animation → confirm live preview updates immediately without saving
- [ ] Set a GTM ID, enable Cookie Consent Banner, edit message text → Save → open the public form → confirm banner appears before GTM fires
- [ ] Accept the banner → confirm GTM loads (check Network tab) → refresh → confirm banner does not reappear
- [ ] Decline the banner → confirm no GTM request is made
- [ ] Confirm `DELETE /submissions/:formId/nonexistent-id` returns `404`
- [ ] Confirm `DELETE /submissions/:formId/:realId` still returns `200`

https://claude.ai/code/session_01YJnQ1P1czxF82KEdMmrMnY