### PR TITLE
feat: flat-rate pricing filter for select fields (v0.7.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.7.7] - 2026-05-13
+
+### Added
+- **Flat-rate Pricing Filter** — Select/single-choice fields now support a "Flat-rate Pricing Filter" option in the form editor. When enabled, you link the field to a guest-count (or quantity) field and set a price-per-person rate (e.g. 40 €/person). Budget options whose upper bound falls below the calculated minimum cost (guests × rate) are automatically hidden from respondents. Each option gets a configurable "Max budget" ceiling in the editor. Plain string options (no ceiling set) are always shown, ensuring full backward compatibility.
+
 ## [0.7.6] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.7.6
+# 🌊 OpenFlow v0.7.7
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -1,6 +1,30 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import './FormRenderer.css';
 
+// Extract the highest number from a string like "51-100 guests" → 100, or "100+" → 100
+function parseGuestCount(answer) {
+  if (answer === undefined || answer === null || answer === '') return null;
+  if (typeof answer === 'number') return answer;
+  const nums = String(answer).match(/\d+/g);
+  if (!nums || nums.length === 0) return null;
+  return Math.max(...nums.map(Number));
+}
+
+// Filter select/multi-select options based on flat-rate pricing (e.g. 40€/person).
+// Options with a maxBudget below (guestCount × rate) are hidden.
+function applyPricingFilter(step, answers) {
+  const pf = step.pricingFilter;
+  if (!pf?.enabled || !pf.field || !pf.rate) return step;
+  const guestCount = parseGuestCount(answers[pf.field]);
+  if (guestCount === null) return step;
+  const minRequired = guestCount * pf.rate;
+  const filteredOptions = (step.options || []).filter(opt => {
+    if (typeof opt === 'string') return true;
+    return !opt.maxBudget || opt.maxBudget >= minRequired;
+  });
+  return { ...step, options: filteredOptions };
+}
+
 const FIELD_TYPES = {
   text: TextInput,
   email: EmailInput,
@@ -271,6 +295,9 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
   const FieldComponent = FIELD_TYPES[step.type] || TextInput;
 
+  // Flat-rate pricing filter: hide budget options that can't cover the minimum cost
+  const displayStep = applyPricingFilter(step, answers);
+
   const footerLinks = (theme.footerLinks || []).filter(l => l.title && l.url);
 
   const enterHint = showEnterHint && step?.type !== 'textarea' ? (
@@ -318,7 +345,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
           <div className="step-field">
             <FieldComponent
-              step={step}
+              step={displayStep}
               value={answers[step.id]}
               onChange={setAnswer}
             />

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -775,16 +775,32 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
 
           {/* Options for select types */}
           {(step.type === 'select' || step.type === 'multi-select') && (
-            <div className="input-group" style={{ marginTop: 12 }}>
-              <label>Options (one per line)</label>
-              <textarea
-                className="input"
-                rows={4}
-                value={(step.options || []).join('\n')}
-                onChange={e => onChange({ options: e.target.value.split('\n').filter(Boolean) })}
-                placeholder={"Option 1\nOption 2\nOption 3"}
+            <>
+              <div className="input-group" style={{ marginTop: 12 }}>
+                <label>Options</label>
+                {step.pricingFilter?.enabled ? (
+                  <PricingOptionsEditor
+                    options={step.options || []}
+                    onChange={options => onChange({ options })}
+                  />
+                ) : (
+                  <textarea
+                    className="input"
+                    rows={4}
+                    value={(step.options || []).map(o => typeof o === 'string' ? o : o.label).join('\n')}
+                    onChange={e => onChange({ options: e.target.value.split('\n').filter(Boolean) })}
+                    placeholder={"Option 1\nOption 2\nOption 3"}
+                  />
+                )}
+              </div>
+              <PricingFilterEditor
+                pricingFilter={step.pricingFilter}
+                allSteps={allSteps}
+                currentStepId={step.id}
+                options={step.options || []}
+                onChange={(pf, opts) => onChange({ pricingFilter: pf, ...(opts !== undefined ? { options: opts } : {}) })}
               />
-            </div>
+            </>
           )}
 
           {/* Image/Icon Select - visual editor */}
@@ -1071,6 +1087,122 @@ function ConditionEditor({ condition, allSteps, currentStepId, onChange }) {
           {!['is_set', 'is_not_set'].includes(condition.op) && (
             <input className="input" value={condition.value || ''} onChange={e => onChange({ ...condition, value: e.target.value })} placeholder="Value" style={{ width: 'auto', minWidth: 120, padding: '6px 10px', fontSize: 13 }} />
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ===========================
+   PricingOptionsEditor - Per-option label + maxBudget when pricing filter is on
+   =========================== */
+function PricingOptionsEditor({ options, onChange }) {
+  function updateOption(i, changes) {
+    const updated = [...options];
+    updated[i] = { ...updated[i], ...changes };
+    onChange(updated);
+  }
+
+  function addOption() {
+    onChange([...options, { label: '', maxBudget: '' }]);
+  }
+
+  function removeOption(i) {
+    onChange(options.filter((_, idx) => idx !== i));
+  }
+
+  const normalized = options.map(o => typeof o === 'string' ? { label: o, maxBudget: '' } : o);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 140px 28px', gap: 6, fontSize: 12, color: '#888', marginBottom: 2 }}>
+        <span>Option label</span>
+        <span>Max budget (€)</span>
+        <span />
+      </div>
+      {normalized.map((opt, i) => (
+        <div key={i} style={{ display: 'grid', gridTemplateColumns: '1fr 140px 28px', gap: 6, alignItems: 'center' }}>
+          <input
+            className="input"
+            value={opt.label || ''}
+            onChange={e => updateOption(i, { label: e.target.value })}
+            placeholder="e.g. 1000–2000€"
+            style={{ fontSize: 13 }}
+          />
+          <input
+            className="input"
+            type="number"
+            min={0}
+            value={opt.maxBudget === '' || opt.maxBudget === undefined ? '' : opt.maxBudget}
+            onChange={e => updateOption(i, { maxBudget: e.target.value === '' ? '' : Number(e.target.value) })}
+            placeholder="upper bound"
+            style={{ fontSize: 13 }}
+          />
+          <button className="btn btn-sm btn-danger" onClick={() => removeOption(i)} style={{ padding: '4px 8px' }}>×</button>
+        </div>
+      ))}
+      <button className="btn btn-secondary btn-sm" onClick={addOption} style={{ marginTop: 4, alignSelf: 'flex-start' }}>+ Add option</button>
+      <p style={{ fontSize: 11, color: '#999', margin: '4px 0 0' }}>
+        Set the upper bound of each budget range. Options whose ceiling is below the calculated minimum cost will be hidden.
+      </p>
+    </div>
+  );
+}
+
+/* ===========================
+   PricingFilterEditor - Flat-rate pricing filter config for select fields
+   =========================== */
+function PricingFilterEditor({ pricingFilter, allSteps, currentStepId, options, onChange }) {
+  const enabled = !!pricingFilter?.enabled;
+  const otherSteps = allSteps.filter(s => s.id !== currentStepId);
+
+  function toggle() {
+    if (enabled) {
+      // Convert options back to plain strings when disabling
+      const plainOptions = options.map(o => typeof o === 'string' ? o : (o.label || ''));
+      onChange(null, plainOptions);
+    } else {
+      // Convert options to extended objects when enabling
+      const extOptions = options.map(o => typeof o === 'string' ? { label: o, maxBudget: '' } : o);
+      onChange({ enabled: true, field: otherSteps[0]?.id || '', rate: 40 }, extOptions);
+    }
+  }
+
+  return (
+    <div style={{ marginTop: 12, padding: 14, background: '#fafafa', borderRadius: 10, border: '1px solid #eee' }}>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
+        <input type="checkbox" checked={enabled} onChange={toggle} />
+        Flat-rate Pricing Filter
+      </label>
+      {enabled && pricingFilter && (
+        <div style={{ marginTop: 10 }}>
+          <p style={{ fontSize: 12, color: '#636E72', marginBottom: 10 }}>
+            Automatically hide budget options that cannot cover the minimum cost (guests × rate per person).
+          </p>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 13, color: '#636E72' }}>Guest count field</span>
+            <select
+              className="input"
+              value={pricingFilter.field || ''}
+              onChange={e => onChange({ ...pricingFilter, field: e.target.value })}
+              style={{ width: 'auto', minWidth: 140, padding: '6px 10px', fontSize: 13 }}
+            >
+              <option value="">-- Select field --</option>
+              {otherSteps.map(s => (
+                <option key={s.id} value={s.id}>{s.label || s.question || s.id}</option>
+              ))}
+            </select>
+            <span style={{ fontSize: 13, color: '#636E72' }}>× rate</span>
+            <input
+              className="input"
+              type="number"
+              min={1}
+              value={pricingFilter.rate ?? 40}
+              onChange={e => onChange({ ...pricingFilter, rate: Number(e.target.value) || 40 })}
+              style={{ width: 80, padding: '6px 10px', fontSize: 13 }}
+            />
+            <span style={{ fontSize: 13, color: '#636E72' }}>€/person</span>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -1117,7 +1117,7 @@ function PricingOptionsEditor({ options, onChange }) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 6 }}>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 140px 28px', gap: 6, fontSize: 12, color: '#888', marginBottom: 2 }}>
         <span>Option label</span>
-        <span>Max budget (€)</span>
+        <span>Max value</span>
         <span />
       </div>
       {normalized.map((opt, i) => (
@@ -1143,7 +1143,7 @@ function PricingOptionsEditor({ options, onChange }) {
       ))}
       <button className="btn btn-secondary btn-sm" onClick={addOption} style={{ marginTop: 4, alignSelf: 'flex-start' }}>+ Add option</button>
       <p style={{ fontSize: 11, color: '#999', margin: '4px 0 0' }}>
-        Set the upper bound of each budget range. Options whose ceiling is below the calculated minimum cost will be hidden.
+        Set the upper bound for each option. Options whose ceiling falls below the calculated minimum (quantity × rate) will be hidden.
       </p>
     </div>
   );
@@ -1177,10 +1177,10 @@ function PricingFilterEditor({ pricingFilter, allSteps, currentStepId, options, 
       {enabled && pricingFilter && (
         <div style={{ marginTop: 10 }}>
           <p style={{ fontSize: 12, color: '#636E72', marginBottom: 10 }}>
-            Automatically hide budget options that cannot cover the minimum cost (guests × rate per person).
+            Automatically hide options whose maximum value falls below <em>quantity × rate</em>. Useful any time a choice depends on a calculated minimum (e.g. price per person, price per item).
           </p>
           <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-            <span style={{ fontSize: 13, color: '#636E72' }}>Guest count field</span>
+            <span style={{ fontSize: 13, color: '#636E72' }}>Quantity field</span>
             <select
               className="input"
               value={pricingFilter.field || ''}
@@ -1201,7 +1201,7 @@ function PricingFilterEditor({ pricingFilter, allSteps, currentStepId, options, 
               onChange={e => onChange({ ...pricingFilter, rate: Number(e.target.value) || 40 })}
               style={{ width: 80, padding: '6px 10px', fontSize: 13 }}
             />
-            <span style={{ fontSize: 13, color: '#636E72' }}>€/person</span>
+            <span style={{ fontSize: 13, color: '#636E72' }}>per unit</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Adds a **Flat-rate Pricing Filter** toggle to single-choice and multi-choice fields in the form editor
- When enabled, you pick a guest-count field and a price-per-person rate (default 40 €/person); budget options whose upper bound is below `guests × rate` are automatically hidden from respondents
- Each option gets a configurable **Max budget (€)** ceiling in the editor; plain string options (no ceiling) are always shown — fully backward-compatible

## How it works

1. In the form editor, open a **Single Choice** or **Multi-choice** question that acts as a budget selector
2. Check **Flat-rate Pricing Filter** below the options list
3. Select the field that collects the guest count (number input or a range select like "51–100")
4. Set the rate (e.g. `40` for 40 €/person)
5. Enter a **Max budget** ceiling for each option (e.g. `1000` for the "500–1000 €" option)

At render time, `applyPricingFilter()` in `FormRenderer.jsx` extracts the highest number from the guest-count answer (handles plain numbers and range strings like "51–100"), computes the minimum required budget, and strips options whose ceiling falls below it.

## Test plan

- [ ] Create a form with a Number field ("How many guests?") and a Single Choice field ("Budget") with pricing filter enabled, rate = 40
- [ ] Enter 10 guests → all budget options visible
- [ ] Enter 60 guests → options below 2 400 € are hidden
- [ ] Enter 150 guests → options below 6 000 € are hidden
- [ ] Test with a Select (range) guest-count field like "51–100 guests" — filter should use 100 as the count
- [ ] Disable the pricing filter → options revert to plain strings, all visible
- [ ] Existing forms without `pricingFilter` config are unaffected

https://claude.ai/code/session_01LN7KedmZgJFeicPqLwjWAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN7KedmZgJFeicPqLwjWAC)_