### PR TITLE
docs: fix CHANGELOG 0.7.7 pricing filter entry — neutral labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenFlow are documented in this file.
 ## [0.7.7] - 2026-05-13
 
 ### Added
-- **Flat-rate Pricing Filter** — Select/single-choice fields now support a "Flat-rate Pricing Filter" option in the form editor. When enabled, you link the field to a guest-count (or quantity) field and set a price-per-person rate (e.g. 40 €/person). Budget options whose upper bound falls below the calculated minimum cost (guests × rate) are automatically hidden from respondents. Each option gets a configurable "Max budget" ceiling in the editor. Plain string options (no ceiling set) are always shown, ensuring full backward compatibility.
+- **Flat-rate Pricing Filter** — Select/single-choice fields now support a "Flat-rate Pricing Filter" option in the form editor. When enabled, link the field to any quantity field (number of guests, items, seats, etc.) and set a rate per unit. Options whose upper bound ("Max value") falls below the calculated minimum (quantity × rate) are automatically hidden from respondents. Plain string options without a ceiling are always shown, ensuring full backward compatibility.
 
 ## [0.7.6] - 2026-04-16
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Updates the CHANGELOG 0.7.7 entry for the Flat-rate Pricing Filter to match the neutral labels shipped in the editor (\"Quantity field\", \"rate per unit\", \"Max value\") instead of the original catering-specific language (\"guest-count\", \"€/person\", \"Max budget\").

## Test plan
- [ ] Verify CHANGELOG reads correctly under `[0.7.7]`
- [ ] No code changes — docs only

https://claude.ai/code/session_01LN7KedmZgJFeicPqLwjWAC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LN7KedmZgJFeicPqLwjWAC)_