### PR TITLE
fix: restore choice option editing and add editable Next/Submit button labels (v0.7.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.7.8] - 2026-05-13
+
+### Added
+- **Editable Next/Submit button labels** — The Design tab's "Button & Navigation" section now exposes "Next Button Label" and "Submit Button Label" fields. Leave blank to keep the defaults ("Next →" / "Submit →"). Labels are stored in the form theme and reflected immediately in the live preview.
+
+### Fixed
+- **Choice option editing — cannot re-add deleted lines** — Deleting all characters from a choice option line and pressing Enter to add a new option was silently no-oped because `filter(Boolean)` stripped the trailing blank line before the textarea re-rendered. The options editor now uses local state so trailing newlines are preserved while typing, allowing new options to be added freely again.
+
 ## [0.7.7] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.7.7
+# 🌊 OpenFlow v0.7.8
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -308,7 +308,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
   const nextButton = (
     <button className="form-btn" onClick={next}>
-      {isLastStep ? 'Submit' : 'Next'} &#8594;
+      {isLastStep ? (theme.submitButtonLabel || 'Submit') : (theme.nextButtonLabel || 'Next')} &#8594;
     </button>
   );
 

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -425,6 +425,26 @@ export default function FormEditor() {
                   Auto-advance only works for choice-based fields (single choice, multiple choice, yes/no, rating, image select).
                 </span>
               </div>
+              <div className="input-group">
+                <label>Next Button Label</label>
+                <input
+                  className="input"
+                  value={form.theme?.nextButtonLabel || ''}
+                  onChange={e => setForm({ ...form, theme: { ...form.theme, nextButtonLabel: e.target.value } })}
+                  placeholder="Next"
+                />
+                <span style={{ fontSize: 11, color: '#999', marginTop: 4, display: 'block' }}>Leave blank to use the default "Next →"</span>
+              </div>
+              <div className="input-group">
+                <label>Submit Button Label</label>
+                <input
+                  className="input"
+                  value={form.theme?.submitButtonLabel || ''}
+                  onChange={e => setForm({ ...form, theme: { ...form.theme, submitButtonLabel: e.target.value } })}
+                  placeholder="Submit"
+                />
+                <span style={{ fontSize: 11, color: '#999', marginTop: 4, display: 'block' }}>Leave blank to use the default "Submit →"</span>
+              </div>
             </div>
           </div>
 
@@ -784,13 +804,7 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
                     onChange={options => onChange({ options })}
                   />
                 ) : (
-                  <textarea
-                    className="input"
-                    rows={4}
-                    value={(step.options || []).map(o => typeof o === 'string' ? o : o.label).join('\n')}
-                    onChange={e => onChange({ options: e.target.value.split('\n').filter(Boolean) })}
-                    placeholder={"Option 1\nOption 2\nOption 3"}
-                  />
+                  <OptionsTextarea options={step.options || []} onChange={onChange} />
                 )}
               </div>
               <PricingFilterEditor
@@ -918,6 +932,39 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
         </div>
       )}
     </div>
+  );
+}
+
+/* ===========================
+   OptionsTextarea - Textarea for editing select/multi-select options
+   Uses local state so trailing newlines are preserved while typing
+   =========================== */
+function OptionsTextarea({ options, onChange }) {
+  const toText = opts => (opts || []).map(o => typeof o === 'string' ? o : o.label).join('\n');
+  const [text, setText] = useState(() => toText(options));
+  const prevText = useRef(text);
+
+  // Sync if parent changes options externally (e.g. switching steps)
+  const canonicalText = toText(options);
+  if (canonicalText !== toText(prevText.current.split('\n').filter(Boolean))) {
+    if (text.split('\n').filter(Boolean).join('\n') !== canonicalText) {
+      setText(canonicalText);
+    }
+  }
+
+  return (
+    <textarea
+      className="input"
+      rows={4}
+      value={text}
+      onChange={e => {
+        const val = e.target.value;
+        setText(val);
+        prevText.current = val;
+        onChange({ options: val.split('\n').filter(Boolean) });
+      }}
+      placeholder={"Option 1\nOption 2\nOption 3"}
+    />
   );
 }
 
@@ -1354,7 +1401,7 @@ function ThemePreview({ theme }) {
           border: 'none', padding: '10px 22px',
           borderRadius: 8, fontSize: 14, fontWeight: 600, cursor: 'default',
         }}>
-          Next →
+          {theme.nextButtonLabel || 'Next'} →
         </button>
       </div>
       {bgAnimation === 'none' && (


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug fix**: Deleting a choice option line and trying to add a new one was permanently broken — `filter(Boolean)` stripped the trailing newline on every keystroke, so the textarea could never grow back. The options editor now keeps local state for the raw text while typing, so trailing newlines are preserved and new options can always be added.
- **Feature**: Two new fields in the Design tab → "Button & Navigation" section — **Next Button Label** and **Submit Button Label** — let form authors customise the button text (e.g. "Continue", "Send it!"). Defaults remain "Next" / "Submit" when left blank. The live preview in the Design tab also reflects the custom label.

## Test plan

- [ ] Open a Single Choice or Multiple Choice field editor
- [ ] Delete one or more option lines so the textarea has a trailing empty line, press Enter — verify a new option can be typed and saved
- [ ] Open Design tab → Button & Navigation, set "Next Button Label" to "Continue" and "Submit Button Label" to "Done"
- [ ] Verify the live preview button shows "Continue →"
- [ ] Publish the form and navigate through it — intermediate steps show "Continue →", last step shows "Done →"
- [ ] Clear the labels and verify defaults ("Next →" / "Submit →") are restored

https://claude.ai/code/session_01NAjAGnHCKRBYb6RquzX6VV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAjAGnHCKRBYb6RquzX6VV)_