### PR TITLE
feat: white-label branding settings — replaceable/hideable sidebar lo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.8.0] - 2026-05-14
+
+### Added
+- **White-label branding settings** — A new admin-only "Settings" page (sidebar → Settings) lets admins customise the sidebar logo: replace it with any custom logo URL, or hide it entirely. Settings are persisted in a new `site_settings` database table and served via `GET /api/settings` (public) / `PUT /api/settings/:key` (admin-only). The sidebar logo in `App.jsx` is now fully dynamic.
+
 ## [0.7.9] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.7.9
+# 🌊 OpenFlow v0.8.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -9,6 +9,7 @@ const submissionRoutes = require('./routes/submissions');
 const publicRoutes = require('./routes/public');
 const integrationRoutes = require('./routes/integrations');
 const analyticsRoutes = require('./routes/analytics');
+const settingsRoutes = require('./routes/settings');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -24,6 +25,7 @@ app.use('/api/submissions', submissionRoutes);
 app.use('/api/public', publicRoutes);
 app.use('/api/integrations', integrationRoutes);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/settings', settingsRoutes);
 
 // API 404 handler (must come before static file serving)
 app.all('/api/*', (req, res) => {

--- a/backend/src/models/db.js
+++ b/backend/src/models/db.js
@@ -81,6 +81,11 @@ function initDb() {
 
     CREATE INDEX IF NOT EXISTS idx_analytics_form ON analytics_events(form_id, event, created_at);
     CREATE INDEX IF NOT EXISTS idx_analytics_session ON analytics_events(form_id, session_id);
+
+    CREATE TABLE IF NOT EXISTS site_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL DEFAULT '{}'
+    );
   `);
 
   // Migrate: add role column if missing (existing DBs)

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -1,0 +1,45 @@
+const { Router } = require('express');
+const { getDb } = require('../models/db');
+const { authMiddleware } = require('../middleware/auth');
+
+const router = Router();
+
+const ALLOWED_KEYS = ['branding'];
+
+function getSetting(db, key) {
+  const row = db.prepare('SELECT value FROM site_settings WHERE key = ?').get(key);
+  return row ? JSON.parse(row.value) : null;
+}
+
+// GET /api/settings — public, returns all settings
+router.get('/', (req, res) => {
+  const db = getDb();
+  const rows = db.prepare('SELECT key, value FROM site_settings').all();
+  const settings = {};
+  for (const row of rows) {
+    settings[row.key] = JSON.parse(row.value);
+  }
+  res.json({ settings });
+});
+
+// PUT /api/settings/:key — admin only
+router.put('/:key', authMiddleware, (req, res) => {
+  const db = getDb();
+  const user = db.prepare('SELECT role FROM users WHERE id = ?').get(req.userId);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ error: 'Admin only' });
+  }
+
+  const { key } = req.params;
+  if (!ALLOWED_KEYS.includes(key)) {
+    return res.status(400).json({ error: 'Unknown settings key' });
+  }
+
+  const value = req.body;
+  db.prepare('INSERT INTO site_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value')
+    .run(key, JSON.stringify(value));
+
+  res.json({ ok: true, [key]: value });
+});
+
+module.exports = router;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,8 +7,9 @@ import FormEditor from './pages/FormEditor';
 import Submissions from './pages/Submissions';
 import Users from './pages/Users';
 import Analytics from './pages/Analytics';
+import Settings from './pages/Settings';
 
-const APP_VERSION = '0.7.9';
+const APP_VERSION = '0.8.0';
 
 function getInitialTheme() {
   return localStorage.getItem('of_theme') || 'auto';
@@ -18,11 +19,15 @@ export default function App() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [theme, setTheme] = useState(getInitialTheme);
+  const [branding, setBranding] = useState({ logoVisible: true, logoUrl: '' });
   const navigate = useNavigate();
   const location = useLocation();
 
   useEffect(() => {
-    api.me().then(d => setUser(d.user)).catch(() => setUser(null)).finally(() => setLoading(false));
+    Promise.all([
+      api.me().then(d => setUser(d.user)).catch(() => setUser(null)),
+      api.getSettings().then(d => { if (d.settings?.branding) setBranding(b => ({ ...b, ...d.settings.branding })); }).catch(() => {}),
+    ]).finally(() => setLoading(false));
   }, []);
 
   useEffect(() => {
@@ -63,6 +68,7 @@ export default function App() {
           <Link to="/" className={location.pathname === '/' ? 'active' : ''}>Forms</Link>
           <Link to="/analytics" className={location.pathname === '/analytics' ? 'active' : ''}>Analytics</Link>
           {isAdmin && <Link to="/users" className={location.pathname === '/users' ? 'active' : ''}>Users</Link>}
+          {isAdmin && <Link to="/settings" className={location.pathname === '/settings' ? 'active' : ''}>Settings</Link>}
         </nav>
         <div style={{ marginTop: 'auto', paddingTop: 16 }}>
           <span style={{ fontSize: 13, opacity: 0.5, display: 'block', padding: '0 12px', marginBottom: 8 }}>{user.email}</span>
@@ -73,7 +79,13 @@ export default function App() {
             Log out
           </button>
           <a href="https://github.com/vidual-labs/openflow" target="_blank" rel="noopener noreferrer" style={{ display: 'block', fontSize: 12, color: 'rgba(255,255,255,0.3)', padding: '8px 12px', textDecoration: 'none' }}>
-            <img src="/vidual-logo.png" alt="Vidual" style={{ height: 18, opacity: 0.4, display: 'block', marginBottom: 4 }} />
+            {branding.logoVisible && (
+              <img
+                src={branding.logoUrl || '/vidual-logo.png'}
+                alt="Logo"
+                style={{ height: 18, opacity: 0.4, display: 'block', marginBottom: 4, maxWidth: 120, objectFit: 'contain' }}
+              />
+            )}
             v{APP_VERSION} &middot; GitHub
           </a>
         </div>
@@ -85,6 +97,7 @@ export default function App() {
           <Route path="/forms/:id/submissions" element={<Submissions />} />
           <Route path="/analytics" element={<Analytics />} />
           {isAdmin && <Route path="/users" element={<Users />} />}
+          {isAdmin && <Route path="/settings" element={<Settings />} />}
         </Routes>
       </main>
     </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -55,6 +55,9 @@ export const api = {
   getAnalyticsOverview: (days = 30) => request(`/analytics/overview?days=${days}`),
   getAnalyticsDetail: (formId, days = 30) => request(`/analytics/${formId}?days=${days}`),
 
+  getSettings: () => request('/settings'),
+  updateSettings: (key, value) => request(`/settings/${key}`, { method: 'PUT', body: JSON.stringify(value) }),
+
   getPublicForm: (slug) => request(`/public/form/${slug}`),
   submitForm: (slug, data) => request(`/public/form/${slug}/submit`, { method: 'POST', body: JSON.stringify({ data }) }),
 };

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,0 +1,98 @@
+import React, { useState, useEffect } from 'react';
+import { api } from '../api';
+
+const DEFAULT_BRANDING = { logoVisible: true, logoUrl: '' };
+
+export default function Settings() {
+  const [branding, setBranding] = useState(DEFAULT_BRANDING);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api.getSettings()
+      .then(d => {
+        if (d.settings?.branding) setBranding({ ...DEFAULT_BRANDING, ...d.settings.branding });
+      })
+      .catch(() => {});
+  }, []);
+
+  async function handleSave(e) {
+    e.preventDefault();
+    setError('');
+    setSaved(false);
+    try {
+      await api.updateSettings('branding', branding);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: 24 }}>
+        <h2>Settings</h2>
+      </div>
+
+      <form onSubmit={handleSave}>
+        <div className="card" style={{ marginBottom: 16 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 20 }}>
+            <span style={{ fontSize: 20 }}>🎨</span>
+            <div>
+              <h3 style={{ margin: 0 }}>Branding</h3>
+              <p style={{ color: 'var(--text-light)', fontSize: 13, margin: 0 }}>Customise the logo shown at the bottom of the admin sidebar.</p>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+            <div className="input-group">
+              <label>Sidebar Logo</label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 15, cursor: 'pointer', marginTop: 8 }}>
+                <input
+                  type="checkbox"
+                  checked={branding.logoVisible}
+                  onChange={e => setBranding(b => ({ ...b, logoVisible: e.target.checked }))}
+                  style={{ width: 20, height: 20, accentColor: 'var(--primary)' }}
+                />
+                Show logo in sidebar
+              </label>
+              <span style={{ fontSize: 11, color: '#999', marginTop: 8, display: 'block' }}>
+                Uncheck to hide the logo entirely from the sidebar footer.
+              </span>
+            </div>
+
+            <div className="input-group">
+              <label>Logo URL</label>
+              <input
+                className="input"
+                type="url"
+                value={branding.logoUrl}
+                onChange={e => setBranding(b => ({ ...b, logoUrl: e.target.value }))}
+                placeholder="https://example.com/logo.png"
+                disabled={!branding.logoVisible}
+              />
+              <span style={{ fontSize: 11, color: '#999', marginTop: 4, display: 'block' }}>
+                Leave blank to use the built-in default logo. Best results: white PNG/SVG, max height 24px.
+              </span>
+            </div>
+          </div>
+
+          {branding.logoVisible && branding.logoUrl && (
+            <div style={{ marginTop: 16, padding: 16, background: '#2D3436', borderRadius: 10, display: 'inline-flex', alignItems: 'center', gap: 12 }}>
+              <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>Preview:</span>
+              <img src={branding.logoUrl} alt="Logo preview" style={{ height: 20, maxWidth: 140, objectFit: 'contain' }} />
+            </div>
+          )}
+        </div>
+
+        {error && <p style={{ color: 'var(--danger)', marginBottom: 12, fontSize: 14 }}>{error}</p>}
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <button className="btn btn-primary" type="submit">Save Settings</button>
+          {saved && <span style={{ fontSize: 14, color: 'var(--success, #00b894)' }}>Saved!</span>}
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
…go (v0.8.0)

Adds a site_settings table and GET/PUT /api/settings API. Admin users can now visit Settings in the sidebar to set a custom logo URL or hide the logo entirely. The sidebar logo in App.jsx reads from the branding settings on load, falling back to the built-in default when no custom URL is set.

https://claude.ai/code/session_01NAjAGnHCKRBYb6RquzX6VV