### PR TITLE
Fix flat-rate pricing filter (all options pre-selected, unclickable) + stale backend version (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.8.1] - 2026-05-19
+
+### Fixed
+- **Flat-rate pricing filter — options appeared pre-selected and unclickable** — When the flat-rate pricing filter was enabled on a select/multi-select field, every option in the live form rendered with the "selected" highlight and clicking a choice never advanced the form. Options stored in pricing-filter mode are `{ label, maxBudget }` objects with no `value` field, so `opt.value` was `undefined` for every option; `value === undefined` then matched every button and `onChange(undefined)` failed the required-field check. `SelectInput` and `MultiSelectInput` now fall back to `opt.label` when `opt.value` is absent.
+- **Backend status endpoint reported stale version** — `GET /` returned a hardcoded `0.7.6` even though the project was at 0.8.0. The version is now read from `package.json` so it can never drift again.
+
 ## [0.8.0] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.8.0
+# 🌊 OpenFlow v0.8.1
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "1.0.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "1.0.0",
+      "version": "0.8.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const path = require('path');
+const { version } = require('../package.json');
 const { initDb } = require('./models/db');
 const authRoutes = require('./routes/auth');
 const formRoutes = require('./routes/forms');
@@ -41,7 +42,7 @@ app.get('*', (req, res) => {
   if (fs.existsSync(indexPath)) {
     res.sendFile(indexPath);
   } else {
-    res.status(200).json({ status: 'OpenFlow API running', version: '0.7.6' });
+    res.status(200).json({ status: 'OpenFlow API running', version });
   }
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -461,7 +461,7 @@ function SelectInput({ step, value, onChange }) {
   return (
     <div className="form-options">
       {options.map((opt, i) => {
-        const optValue = typeof opt === 'string' ? opt : opt.value;
+        const optValue = typeof opt === 'string' ? opt : (opt.value ?? opt.label);
         const optLabel = typeof opt === 'string' ? opt : opt.label;
         return (
           <button key={i} className={`form-option ${value === optValue ? 'selected' : ''}`} onClick={() => onChange(optValue)}>
@@ -488,7 +488,7 @@ function MultiSelectInput({ step, value, onChange }) {
   return (
     <div className="form-options">
       {options.map((opt, i) => {
-        const optValue = typeof opt === 'string' ? opt : opt.value;
+        const optValue = typeof opt === 'string' ? opt : (opt.value ?? opt.label);
         const optLabel = typeof opt === 'string' ? opt : opt.label;
         return (
           <button key={i} className={`form-option ${selected.includes(optValue) ? 'selected' : ''}`} onClick={() => toggle(optValue)}>


### PR DESCRIPTION
## Summary

Two unrelated bugs reported together:

### 1. Flat-rate pricing filter — options appeared pre-selected and unclickable
Reproduction: enable the Flat-rate Pricing Filter on a budget select field, link it to a "guests" quantity field, set rate (e.g. 40). On the live form, every budget option rendered with the `selected` highlight and clicking did nothing — the form was stuck.

**Root cause** (`frontend/src/components/FormRenderer.jsx`):
- `PricingOptionsEditor` stores options as `{ label, maxBudget }` — there is no `value` field.
- `SelectInput` / `MultiSelectInput` did `const optValue = typeof opt === 'string' ? opt : opt.value`, so `optValue` was `undefined` for every option.
- The selected check `value === optValue` then evaluated `undefined === undefined` ⇒ `true` for every button (visual "all selected").
- Clicks called `onChange(undefined)`, so the answer stayed empty and the required-field gate blocked navigation.

**Fix:** fall back to `opt.label` when `opt.value` is absent, in both `SelectInput` and `MultiSelectInput`. Plain string options and existing `{ label, value }` options continue to work unchanged.

### 2. Backend version footer was stale
`GET /` in `backend/src/index.js` returned `version: '0.7.6'` even though the project was at 0.8.0. Now reads from `package.json` so it can't drift again.

### Version bump
0.8.0 → 0.8.1 (patch — bug fixes). README, CHANGELOG, both `package.json` files updated.

## Test plan
- [ ] In the form editor, create a select field, enable Flat-rate Pricing Filter, link to a quantity field, set a rate, fill in option labels + max-budget ceilings.
- [ ] Open the public form, answer the quantity question, then verify on the budget step that **only one option at a time is highlighted**, that clicking an option auto-advances, and that the form submits.
- [ ] Verify options whose `maxBudget` is below `quantity × rate` are hidden (existing behaviour, should be unchanged).
- [ ] Repeat for a multi-select field with the same configuration.
- [ ] Hit `GET http://localhost:3000/` (with frontend not built) and confirm the JSON `version` matches `package.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018UUBVM9kAmRF1yPZdf6mNL)_