### PR TITLE
feat: custom placeholder labels for address sub-fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.8.2] - 2026-05-19
+
+### Added
+- **Custom address field labels** — Form builders can now set their own placeholder text for each core address sub-field (Street, Postal Code, City, Country) directly in the field editor. Labels fall back to the locale defaults when left blank, so existing forms are unaffected.
+
 ## [0.8.1] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.8.1
+# 🌊 OpenFlow v0.8.2
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -542,15 +542,16 @@ function AddressInput({ step, value, onChange }) {
     onChange({ ...data, [field]: val });
   }
   const customFields = step.customFields || [];
+  const al = step.addressLabels || {};
   return (
     <div className="form-address">
-      <input className="form-input" type="text" placeholder={locale.addressStreet} value={data.street || ''} onChange={e => update('street', e.target.value)} autoFocus />
+      <input className="form-input" type="text" placeholder={al.street || locale.addressStreet} value={data.street || ''} onChange={e => update('street', e.target.value)} autoFocus />
       <div className="form-address-row">
-        <input className="form-input" type="text" placeholder={locale.addressPostal} value={data.postalCode || ''} onChange={e => update('postalCode', e.target.value)} />
-        <input className="form-input" type="text" placeholder={locale.addressCity} value={data.city || ''} onChange={e => update('city', e.target.value)} />
+        <input className="form-input" type="text" placeholder={al.postalCode || locale.addressPostal} value={data.postalCode || ''} onChange={e => update('postalCode', e.target.value)} />
+        <input className="form-input" type="text" placeholder={al.city || locale.addressCity} value={data.city || ''} onChange={e => update('city', e.target.value)} />
       </div>
       {step.showCountry !== false && (
-        <input className="form-input" type="text" placeholder={locale.addressCountry} value={data.country || ''} onChange={e => update('country', e.target.value)} />
+        <input className="form-input" type="text" placeholder={al.country || locale.addressCountry} value={data.country || ''} onChange={e => update('country', e.target.value)} />
       )}
       {customFields.map((field, idx) => (
         <div key={field.id || idx} style={{ marginTop: 12 }}>

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -858,6 +858,18 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
               <p style={{ fontSize: 13, color: '#636E72', marginBottom: 8 }}>
                 This field automatically collects: <strong>Street</strong>, <strong>Postal Code</strong>, <strong>City</strong>, and optionally <strong>Country</strong>.
               </p>
+
+              {/* Custom placeholder labels for core sub-fields */}
+              <div style={{ marginBottom: 12 }}>
+                <p style={{ fontSize: 13, color: '#636E72', marginBottom: 8 }}>Field labels (leave blank to use defaults):</p>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                  <input className="input" value={(step.addressLabels || {}).street || ''} onChange={e => onChange({ addressLabels: { ...(step.addressLabels || {}), street: e.target.value } })} placeholder="Street and house number *" />
+                  <input className="input" value={(step.addressLabels || {}).postalCode || ''} onChange={e => onChange({ addressLabels: { ...(step.addressLabels || {}), postalCode: e.target.value } })} placeholder="Postal code *" />
+                  <input className="input" value={(step.addressLabels || {}).city || ''} onChange={e => onChange({ addressLabels: { ...(step.addressLabels || {}), city: e.target.value } })} placeholder="City *" />
+                  <input className="input" value={(step.addressLabels || {}).country || ''} onChange={e => onChange({ addressLabels: { ...(step.addressLabels || {}), country: e.target.value } })} placeholder="Country (optional)" />
+                </div>
+              </div>
+
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14 }}>
                 <input type="checkbox" checked={step.showCountry !== false} onChange={e => onChange({ showCountry: e.target.checked })} />
                 Include country field


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Form builders can now type their own label text for each core address sub-field (Street, Postal Code, City, Country) in the field editor
- Labels are stored as `addressLabels` on the step config and used as input placeholders in the live form
- Falls back to locale defaults when left blank — existing forms are completely unaffected

## Test plan

- [ ] Open the form editor and add/select an Address field
- [ ] In the address config section, enter custom text in any of the four label inputs (Street, Postal Code, City, Country)
- [ ] Preview the form — the custom text should appear as the placeholder for the corresponding input
- [ ] Leave a label blank and confirm the locale default placeholder still shows
- [ ] Save and reload — confirm custom labels persist
- [ ] Verify an existing address field with no `addressLabels` still renders correctly

https://claude.ai/code/session_01LAMYkj2EYP8kruLTfJxdyS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAMYkj2EYP8kruLTfJxdyS)_