### PR TITLE
Add Lodgely logo to admin sidebar header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.8.2] - 2026-05-19
+
+### Changed
+- **Sidebar logo** — Replaced the text-based OpenFlow logo in the admin sidebar header with the Lodgely logo image (`/lodgely-logo.png`) at 3rem height.
+
 ## [0.8.1] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.8.1
+# 🌊 OpenFlow v0.8.2
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import Users from './pages/Users';
 import Analytics from './pages/Analytics';
 import Settings from './pages/Settings';
 
-const APP_VERSION = '0.8.0';
+const APP_VERSION = '0.8.2';
 
 function getInitialTheme() {
   return localStorage.getItem('of_theme') || 'auto';
@@ -63,7 +63,9 @@ export default function App() {
   return (
     <div className="admin-layout">
       <aside className="admin-sidebar">
-        <h1><span className="logo-icon">&#9830;</span>OpenFlow</h1>
+        <div className="sidebar-logo">
+          <img src="/lodgely-logo.png" alt="Lodgely" style={{ height: '3rem', objectFit: 'contain' }} />
+        </div>
         <nav>
           <Link to="/" className={location.pathname === '/' ? 'active' : ''}>Forms</Link>
           <Link to="/analytics" className={location.pathname === '/analytics' ? 'active' : ''}>Analytics</Link>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -89,6 +89,11 @@ input, select, textarea {
   padding: 0 8px;
 }
 
+.sidebar-logo {
+  margin-bottom: 32px;
+  padding: 0 8px;
+}
+
 .admin-sidebar h1 .logo-icon {
   display: inline-block;
   width: 28px;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Replaces the text-based "OpenFlow" logo in the admin sidebar with the Lodgely image logo (`/lodgely-logo.png`) at 3rem height
- Adds `.sidebar-logo` CSS class for consistent spacing
- Bumps version to 0.8.2

## Test plan
- [ ] Place `lodgely-logo.png` in `frontend/public/`
- [ ] Start the frontend dev server and verify the Lodgely logo appears at the top of the admin sidebar
- [ ] Check that spacing below the logo (before the nav links) looks correct
- [ ] Verify in both light and dark themes

https://claude.ai/code/session_015GLUnfTVc3i9KpZsPaJfjF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015GLUnfTVc3i9KpZsPaJfjF)_