### PR TITLE
feat: editable form URL slug with old-link redirects (v0.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.9.0] - 2026-05-20
+
+### Added
+- **Editable form URL slug** — Form owners can now change the URL slug under the Embed tab (e.g. `/f/spring-2026-launch` instead of the auto-generated 8-character code). Slugs accept lowercase letters, digits, and hyphens, must be 3–60 characters, and a reserved-word blocklist (`admin`, `api`, `login`, etc.) prevents conflicts. Previously shared URLs keep working: when a slug is changed, the old one is recorded in a new `slug_history` table and the public form route transparently serves the form via either alias, with the response always carrying the current canonical slug so `/f/...` and `/embed/...` redirect to the new URL.
+
 ## [0.8.2] - 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.8.2
+# 🌊 OpenFlow v0.9.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/models/db.js
+++ b/backend/src/models/db.js
@@ -86,6 +86,15 @@ function initDb() {
       key TEXT PRIMARY KEY,
       value TEXT NOT NULL DEFAULT '{}'
     );
+
+    CREATE TABLE IF NOT EXISTS slug_history (
+      old_slug TEXT PRIMARY KEY,
+      form_id TEXT NOT NULL,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (form_id) REFERENCES forms(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_slug_history_form ON slug_history(form_id);
   `);
 
   // Migrate: add role column if missing (existing DBs)

--- a/backend/src/routes/forms.js
+++ b/backend/src/routes/forms.js
@@ -3,6 +3,7 @@ const { getDb } = require('../models/db');
 const { authMiddleware } = require('../middleware/auth');
 const { v4: uuid } = require('uuid');
 const { customAlphabet } = require('nanoid');
+const { validateSlug } = require('../utils/slug');
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 8);
 const router = Router();
@@ -72,7 +73,41 @@ router.put('/:id', (req, res) => {
   const existing = db.prepare('SELECT * FROM forms WHERE id = ? AND user_id = ?').get(req.params.id, req.userId);
   if (!existing) return res.status(404).json({ error: 'Form not found' });
 
-  const { title, steps, end_screen, theme, gtm_id, published } = req.body;
+  const { title, slug, steps, end_screen, theme, gtm_id, published } = req.body;
+
+  // Handle slug change separately: validate, check uniqueness, archive old slug.
+  if (slug !== undefined && slug !== existing.slug) {
+    const v = validateSlug(slug);
+    if (!v.ok) return res.status(400).json({ error: v.error });
+
+    const slugTaken = db.prepare(
+      'SELECT id FROM forms WHERE slug = ? AND id != ?'
+    ).get(slug, req.params.id);
+    if (slugTaken) return res.status(409).json({ error: 'That URL is already in use by another form' });
+
+    const historyTaken = db.prepare(
+      'SELECT form_id FROM slug_history WHERE old_slug = ? AND form_id != ?'
+    ).get(slug, req.params.id);
+    if (historyTaken) return res.status(409).json({ error: 'That URL was previously used by another form and cannot be reused' });
+
+    const updateSlug = db.transaction(() => {
+      // Record the current slug as historical (skip if already an alias of this form).
+      db.prepare(
+        'INSERT OR IGNORE INTO slug_history (old_slug, form_id) VALUES (?, ?)'
+      ).run(existing.slug, req.params.id);
+      // If the new slug was previously an alias of THIS form, remove it from history so it's free as canonical.
+      db.prepare('DELETE FROM slug_history WHERE old_slug = ?').run(slug);
+      db.prepare('UPDATE forms SET slug = ?, updated_at = datetime(\'now\') WHERE id = ?').run(slug, req.params.id);
+    });
+    try {
+      updateSlug();
+    } catch (err) {
+      if (err && err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        return res.status(409).json({ error: 'That URL is already in use' });
+      }
+      throw err;
+    }
+  }
 
   db.prepare(`
     UPDATE forms SET

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -8,9 +8,20 @@ const router = Router();
 // Get published form by slug (public)
 router.get('/form/:slug', (req, res) => {
   const db = getDb();
-  const form = db.prepare(
+  let form = db.prepare(
     'SELECT id, title, slug, steps, end_screen, theme, gtm_id FROM forms WHERE slug = ? AND published = 1'
   ).get(req.params.slug);
+
+  // Fall back to slug history so previously shared URLs keep working after a rename.
+  // The response still carries the canonical slug — the client should swap the URL.
+  if (!form) {
+    const historic = db.prepare('SELECT form_id FROM slug_history WHERE old_slug = ?').get(req.params.slug);
+    if (historic) {
+      form = db.prepare(
+        'SELECT id, title, slug, steps, end_screen, theme, gtm_id FROM forms WHERE id = ? AND published = 1'
+      ).get(historic.form_id);
+    }
+  }
 
   if (!form) return res.status(404).json({ error: 'Form not found' });
 
@@ -34,7 +45,13 @@ router.post('/form/:slug/submit', async (req, res) => {
   }
 
   const db = getDb();
-  const form = db.prepare('SELECT id, title, steps FROM forms WHERE slug = ? AND published = 1').get(req.params.slug);
+  let form = db.prepare('SELECT id, title, steps FROM forms WHERE slug = ? AND published = 1').get(req.params.slug);
+  if (!form) {
+    const historic = db.prepare('SELECT form_id FROM slug_history WHERE old_slug = ?').get(req.params.slug);
+    if (historic) {
+      form = db.prepare('SELECT id, title, steps FROM forms WHERE id = ? AND published = 1').get(historic.form_id);
+    }
+  }
   if (!form) return res.status(404).json({ error: 'Form not found' });
 
   const steps = JSON.parse(form.steps);

--- a/backend/src/utils/slug.js
+++ b/backend/src/utils/slug.js
@@ -1,0 +1,33 @@
+// Slug validation for human-editable form URLs.
+
+const RESERVED_SLUGS = new Set([
+  'admin', 'api', 'login', 'logout', 'embed', 'f',
+  'dashboard', 'forms', 'public', 'assets', 'static',
+  'settings', 'auth', 'signup', 'signin', 'register',
+  'health', 'robots', 'sitemap', 'favicon', 'www',
+]);
+
+const SLUG_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const MIN_LEN = 3;
+const MAX_LEN = 60;
+
+function validateSlug(slug) {
+  if (typeof slug !== 'string') {
+    return { ok: false, error: 'Slug must be a string' };
+  }
+  if (slug.length < MIN_LEN) {
+    return { ok: false, error: `Slug must be at least ${MIN_LEN} characters` };
+  }
+  if (slug.length > MAX_LEN) {
+    return { ok: false, error: `Slug must be at most ${MAX_LEN} characters` };
+  }
+  if (!SLUG_REGEX.test(slug)) {
+    return { ok: false, error: 'Slug may only contain lowercase letters, digits and hyphens (no leading, trailing, or consecutive hyphens)' };
+  }
+  if (RESERVED_SLUGS.has(slug)) {
+    return { ok: false, error: `"${slug}" is reserved and cannot be used` };
+  }
+  return { ok: true };
+}
+
+module.exports = { validateSlug, RESERVED_SLUGS, SLUG_REGEX, MIN_LEN, MAX_LEN };

--- a/backend/tests/slug.test.js
+++ b/backend/tests/slug.test.js
@@ -1,0 +1,239 @@
+const request = require('supertest');
+const bcrypt = require('bcryptjs');
+const { v4: uuid } = require('uuid');
+const { createTestApp } = require('./setup');
+const { validateSlug } = require('../src/utils/slug');
+
+describe('Slug validation (unit)', () => {
+  it('accepts well-formed slugs', () => {
+    expect(validateSlug('my-form').ok).toBe(true);
+    expect(validateSlug('abc').ok).toBe(true);
+    expect(validateSlug('spring-2026-launch').ok).toBe(true);
+    expect(validateSlug('a1b2c3').ok).toBe(true);
+  });
+
+  it('rejects slugs shorter than the minimum', () => {
+    expect(validateSlug('ab').ok).toBe(false);
+  });
+
+  it('rejects slugs longer than the maximum', () => {
+    expect(validateSlug('a'.repeat(61)).ok).toBe(false);
+  });
+
+  it('rejects uppercase characters', () => {
+    expect(validateSlug('MyForm').ok).toBe(false);
+  });
+
+  it('rejects leading and trailing hyphens', () => {
+    expect(validateSlug('-leading').ok).toBe(false);
+    expect(validateSlug('trailing-').ok).toBe(false);
+  });
+
+  it('rejects consecutive hyphens', () => {
+    expect(validateSlug('foo--bar').ok).toBe(false);
+  });
+
+  it('rejects underscores and other special chars', () => {
+    expect(validateSlug('foo_bar').ok).toBe(false);
+    expect(validateSlug('foo bar').ok).toBe(false);
+    expect(validateSlug('foo.bar').ok).toBe(false);
+  });
+
+  it('rejects reserved words', () => {
+    expect(validateSlug('admin').ok).toBe(false);
+    expect(validateSlug('api').ok).toBe(false);
+    expect(validateSlug('login').ok).toBe(false);
+    expect(validateSlug('embed').ok).toBe(false);
+    expect(validateSlug('www').ok).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(validateSlug(123).ok).toBe(false);
+    expect(validateSlug(null).ok).toBe(false);
+    expect(validateSlug(undefined).ok).toBe(false);
+  });
+});
+
+describe('Slug editing & history (integration)', () => {
+  let app;
+  let cookie;
+  let userId;
+  let formId;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  beforeEach(async () => {
+    const db = require('../src/models/db').getDb();
+    db.pragma('foreign_keys = OFF');
+    db.exec('DELETE FROM slug_history');
+    db.pragma('foreign_keys = ON');
+
+    userId = uuid();
+    const hash = bcrypt.hashSync('userpass', 10);
+    db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?, ?, ?, ?)').run(userId, 'slug-tester@test.com', hash, 'user');
+
+    const login = await request(app).post('/api/auth/login').send({ email: 'slug-tester@test.com', password: 'userpass' });
+    cookie = login.headers['set-cookie'];
+
+    const created = await request(app)
+      .post('/api/forms')
+      .set('Cookie', cookie)
+      .send({ title: 'Test Form' });
+    formId = created.body.form.id;
+  });
+
+  it('renames a form to a new slug', async () => {
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'spring-launch' });
+    expect(res.status).toBe(200);
+    expect(res.body.form.slug).toBe('spring-launch');
+  });
+
+  it('archives the old slug in history when changed', async () => {
+    const db = require('../src/models/db').getDb();
+    const original = db.prepare('SELECT slug FROM forms WHERE id = ?').get(formId).slug;
+
+    await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'renamed-form' });
+
+    const history = db.prepare('SELECT * FROM slug_history WHERE old_slug = ?').get(original);
+    expect(history).toBeTruthy();
+    expect(history.form_id).toBe(formId);
+  });
+
+  it('rejects invalid slugs with 400', async () => {
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'INVALID' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects reserved slugs with 400', async () => {
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'admin' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a slug already taken by another form with 409', async () => {
+    const other = await request(app)
+      .post('/api/forms')
+      .set('Cookie', cookie)
+      .send({ title: 'Other Form' });
+    await request(app)
+      .put(`/api/forms/${other.body.form.id}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'taken-slug' });
+
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'taken-slug' });
+    expect(res.status).toBe(409);
+  });
+
+  it('rejects a slug that lives in another form\'s history with 409', async () => {
+    const other = await request(app)
+      .post('/api/forms')
+      .set('Cookie', cookie)
+      .send({ title: 'Other Form' });
+    await request(app)
+      .put(`/api/forms/${other.body.form.id}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'first-name' });
+    await request(app)
+      .put(`/api/forms/${other.body.form.id}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'second-name' });
+
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'first-name' });
+    expect(res.status).toBe(409);
+  });
+
+  it('lets a form reclaim its own previous slug', async () => {
+    await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'alpha' });
+    await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'beta' });
+    const res = await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'alpha' });
+    expect(res.status).toBe(200);
+    expect(res.body.form.slug).toBe('alpha');
+  });
+
+  it('accepts a no-op slug update (same slug)', async () => {
+    const db = require('../src/models/db').getDb();
+    const current = db.prepare('SELECT slug FROM forms WHERE id = ?').get(formId).slug;
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ slug: current });
+    expect(res.status).toBe(200);
+
+    const history = db.prepare('SELECT COUNT(*) as n FROM slug_history WHERE form_id = ?').get(formId);
+    expect(history.n).toBe(0);
+  });
+
+  describe('public form lookup by old slug', () => {
+    it('serves the form via its current canonical slug', async () => {
+      await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'current-slug', published: 1 });
+
+      const res = await request(app).get('/api/public/form/current-slug');
+      expect(res.status).toBe(200);
+      expect(res.body.form.slug).toBe('current-slug');
+    });
+
+    it('serves the form when an old slug is requested, returning the canonical slug', async () => {
+      const db = require('../src/models/db').getDb();
+      const original = db.prepare('SELECT slug FROM forms WHERE id = ?').get(formId).slug;
+
+      await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'new-canonical', published: 1 });
+
+      const res = await request(app).get(`/api/public/form/${original}`);
+      expect(res.status).toBe(200);
+      // Canonical slug is returned regardless of which alias was requested.
+      expect(res.body.form.slug).toBe('new-canonical');
+    });
+
+    it('returns 404 when an old slug points to an unpublished form', async () => {
+      const db = require('../src/models/db').getDb();
+      const original = db.prepare('SELECT slug FROM forms WHERE id = ?').get(formId).slug;
+      await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'new-name' });
+      // Form is still a draft (never published).
+      const res = await request(app).get(`/api/public/form/${original}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for a slug that never existed', async () => {
+      const res = await request(app).get('/api/public/form/nonexistent-slug');
+      expect(res.status).toBe(404);
+    });
+
+    it('accepts submissions through an old slug after a rename', async () => {
+      const db = require('../src/models/db').getDb();
+      const original = db.prepare('SELECT slug FROM forms WHERE id = ?').get(formId).slug;
+
+      await request(app)
+        .put(`/api/forms/${formId}`)
+        .set('Cookie', cookie)
+        .send({
+          slug: 'fresh-slug',
+          published: 1,
+          steps: [{ id: 'name', label: 'Name', type: 'text', required: false }],
+        });
+
+      const res = await request(app)
+        .post(`/api/public/form/${original}/submit`)
+        .send({ data: { name: 'Alice' } });
+      expect(res.status).toBe(201);
+    });
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "1.0.0",
+      "version": "0.9.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/EmbedView.jsx
+++ b/frontend/src/pages/EmbedView.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import FormRenderer from '../components/FormRenderer';
 import { api } from '../api';
 
@@ -45,6 +45,7 @@ function CookieBanner({ form, onAccept, onDecline }) {
 
 export default function EmbedView() {
   const { slug } = useParams();
+  const navigate = useNavigate();
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
   const [cookieConsent, setCookieConsent] = useState(null);
@@ -61,8 +62,16 @@ export default function EmbedView() {
   }, []);
 
   useEffect(() => {
-    api.getPublicForm(slug).then(d => setForm(d.form)).catch(e => setError(e.message));
-  }, [slug]);
+    api.getPublicForm(slug)
+      .then(d => {
+        if (d.form && d.form.slug && d.form.slug !== slug) {
+          navigate(`/embed/${d.form.slug}`, { replace: true });
+          return;
+        }
+        setForm(d.form);
+      })
+      .catch(e => setError(e.message));
+  }, [slug, navigate]);
 
   // Determine cookie consent state once form is loaded
   useEffect(() => {

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -686,6 +686,12 @@ export default function FormEditor() {
             Copy the code and paste it into your landing page.
           </p>
 
+          <SlugEditor
+            form={form}
+            onUpdated={(updated) => setForm(updated)}
+            baseUrl={baseUrl}
+          />
+
           <div className="input-group">
             <label>Direct Link</label>
             <input className="input" readOnly value={`${baseUrl}/f/${form.slug}`} onClick={e => { e.target.select(); navigator.clipboard?.writeText(e.target.value); }} />
@@ -955,6 +961,105 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
           />
         </div>
       )}
+    </div>
+  );
+}
+
+/* ===========================
+   SlugEditor - editable form URL slug
+   =========================== */
+const SLUG_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const SLUG_MIN = 3;
+const SLUG_MAX = 60;
+const SLUG_RESERVED = new Set([
+  'admin', 'api', 'login', 'logout', 'embed', 'f',
+  'dashboard', 'forms', 'public', 'assets', 'static',
+  'settings', 'auth', 'signup', 'signin', 'register',
+  'health', 'robots', 'sitemap', 'favicon', 'www',
+]);
+
+function validateSlugClient(slug) {
+  if (slug.length < SLUG_MIN) return `At least ${SLUG_MIN} characters required.`;
+  if (slug.length > SLUG_MAX) return `At most ${SLUG_MAX} characters allowed.`;
+  if (!SLUG_REGEX.test(slug)) return 'Use only lowercase letters, digits, and hyphens (no leading/trailing or consecutive hyphens).';
+  if (SLUG_RESERVED.has(slug)) return `"${slug}" is reserved and cannot be used.`;
+  return '';
+}
+
+function SlugEditor({ form, onUpdated, baseUrl }) {
+  const [value, setValue] = useState(form.slug);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => { setValue(form.slug); }, [form.slug]);
+
+  const trimmed = value.trim();
+  const clientError = trimmed && trimmed !== form.slug ? validateSlugClient(trimmed) : '';
+  const dirty = trimmed !== form.slug;
+  const canSave = dirty && !clientError && !saving;
+
+  async function save() {
+    setError('');
+    setSaved(false);
+    setSaving(true);
+    try {
+      const { form: updated } = await api.updateForm(form.id, { slug: trimmed });
+      onUpdated(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err.message || 'Failed to update URL');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const displayError = error || clientError;
+
+  return (
+    <div className="input-group">
+      <label>Form URL</label>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'stretch' }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', padding: '0 12px',
+          background: 'rgba(0,0,0,0.04)', border: '1px solid var(--border, #e0e0e0)',
+          borderRight: 'none', borderRadius: '8px 0 0 8px',
+          color: 'var(--text-light)', fontSize: 14, whiteSpace: 'nowrap',
+        }}>
+          {baseUrl}/f/
+        </div>
+        <input
+          className="input"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          spellCheck={false}
+          style={{
+            borderRadius: '0 8px 8px 0',
+            borderLeft: 'none',
+            flex: 1,
+            fontFamily: 'monospace',
+          }}
+          onKeyDown={e => { if (e.key === 'Enter' && canSave) save(); }}
+        />
+        <button
+          className="btn btn-primary"
+          onClick={save}
+          disabled={!canSave}
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          {saving ? 'Saving...' : 'Update URL'}
+        </button>
+      </div>
+      <div style={{ marginTop: 6, minHeight: 18, fontSize: 12 }}>
+        {displayError ? (
+          <span style={{ color: '#E17055' }}>{displayError}</span>
+        ) : saved ? (
+          <span style={{ color: '#00B894' }}>URL updated. The previous URL will redirect to the new one.</span>
+        ) : (
+          <span style={{ color: '#999' }}>Lowercase letters, digits and hyphens. 3–60 characters.</span>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/FormView.jsx
+++ b/frontend/src/pages/FormView.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import FormRenderer from '../components/FormRenderer';
 import { api } from '../api';
 
@@ -45,6 +45,7 @@ function CookieBanner({ form, onAccept, onDecline }) {
 
 export default function FormView() {
   const { slug } = useParams();
+  const navigate = useNavigate();
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
   // null = not yet determined, true = accepted, false = declined, 'pending' = needs banner
@@ -62,8 +63,17 @@ export default function FormView() {
   }, []);
 
   useEffect(() => {
-    api.getPublicForm(slug).then(d => setForm(d.form)).catch(e => setError(e.message));
-  }, [slug]);
+    api.getPublicForm(slug)
+      .then(d => {
+        // If the requested slug is an old alias, swap the URL bar to the canonical one.
+        if (d.form && d.form.slug && d.form.slug !== slug) {
+          navigate(`/f/${d.form.slug}`, { replace: true });
+          return;
+        }
+        setForm(d.form);
+      })
+      .catch(e => setError(e.message));
+  }, [slug, navigate]);
 
   // Determine cookie consent state once form is loaded
   useEffect(() => {


### PR DESCRIPTION
## Summary

Phase 1 of the custom-URL feature: form owners can now edit the URL slug from the Embed tab. Old URLs keep working — when the slug changes, the previous value is archived in a new `slug_history` table and the public form route falls back to it, with the response carrying the canonical slug so the browser swaps the URL bar automatically.

Phase 2 (per-form subdomain under an operator-controlled wildcard domain with a single Let's Encrypt cert via Caddy) is documented in the plan but not in this PR.

## What changed

- **Backend**
  - `backend/src/utils/slug.js` (new): validator with regex `^[a-z0-9]+(-[a-z0-9]+)*$`, length 3–60, reserved-word blocklist (`admin, api, login, embed, f, dashboard, forms, ...`).
  - `backend/src/models/db.js`: new `slug_history` table mapping `old_slug → form_id`.
  - `backend/src/routes/forms.js`: `PUT /api/forms/:id` now accepts `slug`. On change: validate → 400, check uniqueness against current slugs AND other forms' history → 409, archive old slug, then update. A form may reclaim its own previous slug.
  - `backend/src/routes/public.js`: `GET /api/public/form/:slug` and `POST /api/public/form/:slug/submit` fall back to `slug_history` on miss. Response still returns the canonical slug.
- **Frontend**
  - `frontend/src/pages/FormEditor.jsx`: new `SlugEditor` component above the Direct Link in the Embed tab. Live client-side validation, prefix preview, inline 409/400 error surfacing.
  - `frontend/src/pages/FormView.jsx`, `EmbedView.jsx`: when `form.slug` returned by the API doesn't match the URL param, `navigate(..., { replace: true })` swaps the URL bar.
- **Tests**: `backend/tests/slug.test.js` covers validator unit, slug update happy path, history archival, 400 on invalid/reserved, 409 on conflict (live or historical), self-reclaim, no-op update, and public lookup by old slug (published / unpublished / unknown / submissions).
- **Version bump**: `0.8.2 → 0.9.0` in `README.md`, `CHANGELOG.md`, both `package.json` and `package-lock.json`.

## Test plan

- [x] `cd backend && npx jest --runInBand --forceExit tests/slug.test.js` — all new slug tests pass
- [x] `cd frontend && npm run build` — clean build, no errors
- [ ] Manual: create a form, rename its slug under Embed tab, confirm:
  - [ ] Old URL (`/f/<old>`) loads the form and URL bar updates to `/f/<new>`
  - [ ] Same for `/embed/<old>`
  - [ ] Reserved slug like `admin` shows inline validation error before save
  - [ ] Trying to take another form's slug returns 409 with inline error
  - [ ] A form can reclaim its own previously used slug
- [ ] Confirm pre-existing failing tests (`tests/auth.test.js` user management, `tests/validation.test.js` analytics) are not new — they fail on `main` too.

https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4)_