### PR TITLE
feat: per-form custom subdomain hosting with wildcard TLS (v0.10.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,14 @@
 JWT_SECRET=your-secret-key-here
 ADMIN_EMAIL=admin@openflow.local
 ADMIN_PASSWORD=admin123
+
+# --- Custom subdomains (optional) ---
+# When set, the backend serves a single form on each <subdomain>.OPENFLOW_PRIMARY_HOST.
+# Admin UI continues to live on the apex/primary host.
+# OPENFLOW_PRIMARY_HOST=forms.example.com
+
+# Required when using docker-compose.subdomains.yml. Caddy uses these to acquire
+# a single wildcard certificate via the DNS-01 ACME challenge. Replace the
+# provider plugin and token to match the DNS account that owns OPENFLOW_PRIMARY_HOST.
+# CADDY_DNS_PROVIDER=cloudflare
+# CADDY_DNS_TOKEN=your-dns-api-token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.10.0] - 2026-05-23
+
+### Added
+- **Per-form subdomain hosting** — Each form can now be served on its own subdomain of an operator-controlled parent host (e.g. `acme.forms.example.com`). Set `OPENFLOW_PRIMARY_HOST` and the Embed tab gains a "Custom subdomain" field next to the form URL. Requests to a configured subdomain receive an injected form identity in `index.html`; the SPA boots in form-only mode, admin APIs return 404, and the URL bar stays at `/`. A new `Caddyfile` plus opt-in `docker-compose.subdomains.yml` overlay terminates TLS with a single wildcard certificate via the Let's Encrypt DNS-01 challenge — one cert covers every form, no per-tenant verification or on-demand TLS required. Validation reuses the slug grammar `[a-z0-9-]{3,60}` and applies a hostname-specific reserved-word blocklist (`www`, `api`, `admin`, `mail`, …) to prevent conflicts.
+
 ## [0.9.0] - 2026-05-20
 
 ### Added

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,22 @@
+# OpenFlow Caddyfile — fronts the backend with TLS for the primary host
+# and a single wildcard cert that covers every per-form subdomain.
+#
+# The wildcard cert is issued via the DNS-01 ACME challenge, which is the
+# only Let's Encrypt challenge type that can produce a *.<domain> cert.
+# This requires a Caddy build that includes a DNS-provider plugin for the
+# zone hosting OPENFLOW_PRIMARY_HOST (see docker-compose.subdomains.yml).
+
+{
+	# Email is optional but recommended — Let's Encrypt sends expiry warnings here.
+	email {$CADDY_ACME_EMAIL:admin@openflow.local}
+}
+
+# Match the primary host and every single-label subdomain underneath it.
+*.{$OPENFLOW_PRIMARY_HOST}, {$OPENFLOW_PRIMARY_HOST} {
+	tls {
+		dns {$CADDY_DNS_PROVIDER} {$CADDY_DNS_TOKEN}
+	}
+
+	encode zstd gzip
+	reverse_proxy app:3000
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.9.0
+# 🌊 OpenFlow v0.10.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 
@@ -257,6 +257,27 @@ window.addEventListener('message', function(e) {
 ```
 
 Also available as a **WPBakery element** and **Gutenberg block**.
+
+### Custom Subdomains
+
+Serve each form on its own subdomain of a host you control (e.g. `acme.forms.example.com`). Every form gets a vanity URL that's friendlier than `/f/<slug>` and looks tenant-owned.
+
+**One-time operator setup:**
+
+1. Set `OPENFLOW_PRIMARY_HOST` to the apex you control (e.g. `forms.example.com`) in `.env`.
+2. Add a wildcard DNS record at your provider: `*.forms.example.com → <your server IP>` (A/AAAA).
+3. Choose a DNS provider that has a Caddy plugin (Cloudflare, Route53, DigitalOcean, …). Create an API token scoped to the zone and set `CADDY_DNS_PROVIDER` and `CADDY_DNS_TOKEN` in `.env`.
+4. Use the subdomain-aware compose overlay:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.subdomains.yml up -d --build
+```
+
+Caddy fronts the app on ports 80/443 and provisions a **single wildcard certificate** via Let's Encrypt's DNS-01 challenge. The cert covers every form forever; renewal is automatic.
+
+> **Note**: the default `caddy:2-alpine` image does not include DNS provider plugins. Either use a community image such as `slothcroissant/caddy-cloudflaredns` (set `CADDY_IMAGE` in `.env`) or build your own with `xcaddy`.
+
+**Per form:** open the form's Embed tab → enter a subdomain label (lowercase letters, digits, hyphens; 3–60 chars; not `www`, `api`, `admin`, etc.). Publish the form. Visitors at `https://<label>.<your-host>` see the form; admin paths return 404 on the subdomain.
 
 ---
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -11,13 +11,23 @@ const publicRoutes = require('./routes/public');
 const integrationRoutes = require('./routes/integrations');
 const analyticsRoutes = require('./routes/analytics');
 const settingsRoutes = require('./routes/settings');
+const { createSubdomainMiddleware } = require('./middleware/subdomain');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Trust X-Forwarded-* headers so req.hostname reflects the Host header
+// that Caddy (or any other reverse proxy) saw from the client.
+app.set('trust proxy', true);
+
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json({ limit: '50mb' }));
 app.use(cookieParser());
+
+// Resolve the per-form subdomain (if any) before any other route runs so
+// admin APIs can be blocked and the catch-all can inject the form slug
+// into index.html.
+app.use(createSubdomainMiddleware());
 
 // API routes
 app.use('/api/auth', authRoutes);
@@ -36,14 +46,43 @@ app.all('/api/*', (req, res) => {
 // Serve frontend
 const fs = require('fs');
 const publicDir = path.join(__dirname, '../public');
-app.use(express.static(publicDir));
-app.get('*', (req, res) => {
+// Disable static's automatic index.html serving so the catch-all below can
+// inject window.__OPENFLOW_HOST_FORM__ on subdomain hosts. Other assets
+// (JS, CSS, images) still get served by the static middleware.
+app.use(express.static(publicDir, { index: false }));
+
+// Cache the unmodified index.html bytes so we don't hit disk on every SPA route.
+let cachedIndexHtml = null;
+function readIndexHtml() {
+  if (cachedIndexHtml !== null) return cachedIndexHtml;
   const indexPath = path.join(publicDir, 'index.html');
-  if (fs.existsSync(indexPath)) {
-    res.sendFile(indexPath);
-  } else {
-    res.status(200).json({ status: 'OpenFlow API running', version });
+  if (!fs.existsSync(indexPath)) return null;
+  cachedIndexHtml = fs.readFileSync(indexPath, 'utf8');
+  return cachedIndexHtml;
+}
+
+function escapeForJsString(s) {
+  // Only safe characters end up here (slugs are [a-z0-9-]), but escape
+  // defensively so a future change can't smuggle JS into the page.
+  return String(s).replace(/[\\'"<>&]/g, c => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`);
+}
+
+function injectSubdomainForm(html, form) {
+  const payload = `{"slug":"${escapeForJsString(form.slug)}","id":"${escapeForJsString(form.id)}"}`;
+  const tag = `<script>window.__OPENFLOW_HOST_FORM__=${payload};</script>`;
+  if (html.includes('</head>')) return html.replace('</head>', `${tag}</head>`);
+  return tag + html;
+}
+
+app.get('*', (req, res) => {
+  const html = readIndexHtml();
+  if (!html) {
+    return res.status(200).json({ status: 'OpenFlow API running', version });
   }
+  if (req.subdomainForm) {
+    return res.type('html').send(injectSubdomainForm(html, req.subdomainForm));
+  }
+  res.type('html').send(html);
 });
 
 async function start() {

--- a/backend/src/middleware/subdomain.js
+++ b/backend/src/middleware/subdomain.js
@@ -1,0 +1,93 @@
+// Subdomain routing middleware.
+//
+// When OPENFLOW_PRIMARY_HOST is set and a request arrives on a non-www
+// subdomain of it (e.g. acme.openflow.example.com), this middleware:
+//   1. Resolves the form claiming that subdomain (published only).
+//   2. Attaches it to req.subdomainForm so the SPA-serving catch-all can
+//      inject the form slug into index.html.
+//   3. Blocks admin APIs (return 404 JSON) so the form-only host can't reach
+//      authenticated endpoints even if a client tries.
+//   4. Lets static assets + /api/public/* + /f/* + /embed/* pass through.
+//
+// Requests to the primary host (or any host that doesn't match) are
+// untouched, so existing deployments continue to behave exactly as before.
+
+const { getDb } = require('../models/db');
+
+// Paths that, on a subdomain, return 404 because they would expose admin UI
+// or admin APIs. The catch-all SPA serves index.html for anything not in this
+// list; React Router on the client only has FormView / EmbedView in scope for
+// subdomain visits, so untracked client routes fall back to FormView anyway.
+const ADMIN_PATH_PREFIXES = [
+  '/api/auth',
+  '/api/forms',
+  '/api/submissions',
+  '/api/integrations',
+  '/api/analytics',
+  '/api/settings',
+];
+
+function isAdminPath(p) {
+  for (const prefix of ADMIN_PATH_PREFIXES) {
+    if (p === prefix || p.startsWith(prefix + '/')) return true;
+  }
+  return false;
+}
+
+function extractSubdomain(hostname, primaryHost) {
+  if (!hostname || !primaryHost) return null;
+  const h = hostname.toLowerCase();
+  const p = primaryHost.toLowerCase();
+  if (h === p) return null;
+  const suffix = '.' + p;
+  if (!h.endsWith(suffix)) return null;
+  const prefix = h.slice(0, h.length - suffix.length);
+  if (!prefix) return null;
+  // Permit only a single label (no nested subdomains).
+  if (prefix.includes('.')) return null;
+  return prefix;
+}
+
+function createSubdomainMiddleware() {
+  return function subdomainMiddleware(req, res, next) {
+    const primaryHost = process.env.OPENFLOW_PRIMARY_HOST;
+    if (!primaryHost) return next();
+
+    const sub = extractSubdomain(req.hostname, primaryHost);
+    if (!sub || sub === 'www') return next();
+
+    let form;
+    try {
+      form = getDb().prepare(
+        'SELECT id, slug, title FROM forms WHERE subdomain = ? AND published = 1'
+      ).get(sub);
+    } catch {
+      // DB lookup failure shouldn't take down the primary host — fall through.
+      return next();
+    }
+
+    if (!form) {
+      // Subdomain looks like ours but no form claims it. Show a clean 404
+      // rather than the admin landing page.
+      return res.status(404).type('text/plain').send('Form not found');
+    }
+
+    req.subdomainForm = form;
+
+    if (req.path.startsWith('/api/') && isAdminPath(req.path)) {
+      // Admin APIs don't exist on per-form subdomains.
+      return res.status(404).json({ error: 'Not available on this hostname' });
+    }
+
+    // Force any direct request for the raw index file through the catch-all
+    // (which injects window.__OPENFLOW_HOST_FORM__), rather than letting the
+    // static middleware serve the un-injected HTML.
+    if (req.path === '/index.html') {
+      req.url = '/' + req.url.slice('/index.html'.length);
+    }
+
+    return next();
+  };
+}
+
+module.exports = { createSubdomainMiddleware, extractSubdomain, isAdminPath };

--- a/backend/src/models/db.js
+++ b/backend/src/models/db.js
@@ -105,6 +105,17 @@ function initDb() {
     console.log('Migration: added role column to users');
   }
 
+  // Migrate: add subdomain column to forms (existing DBs).
+  // SQLite can't add a column with a UNIQUE constraint inline, so we add the
+  // column nullable and enforce uniqueness with a partial unique index.
+  try {
+    db.prepare('SELECT subdomain FROM forms LIMIT 1').get();
+  } catch {
+    db.exec('ALTER TABLE forms ADD COLUMN subdomain TEXT');
+    console.log('Migration: added subdomain column to forms');
+  }
+  db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_forms_subdomain ON forms(subdomain) WHERE subdomain IS NOT NULL');
+
   // Seed admin user
   const adminEmail = process.env.ADMIN_EMAIL || 'admin@openflow.local';
   const adminPassword = process.env.ADMIN_PASSWORD || 'admin123';

--- a/backend/src/routes/forms.js
+++ b/backend/src/routes/forms.js
@@ -4,6 +4,7 @@ const { authMiddleware } = require('../middleware/auth');
 const { v4: uuid } = require('uuid');
 const { customAlphabet } = require('nanoid');
 const { validateSlug } = require('../utils/slug');
+const { validateSubdomain } = require('../utils/subdomain');
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 8);
 const router = Router();
@@ -73,7 +74,31 @@ router.put('/:id', (req, res) => {
   const existing = db.prepare('SELECT * FROM forms WHERE id = ? AND user_id = ?').get(req.params.id, req.userId);
   if (!existing) return res.status(404).json({ error: 'Form not found' });
 
-  const { title, slug, steps, end_screen, theme, gtm_id, published } = req.body;
+  const { title, slug, subdomain, steps, end_screen, theme, gtm_id, published } = req.body;
+
+  // Handle subdomain change separately: validate, check uniqueness.
+  // null/empty string clears it.
+  if (subdomain !== undefined) {
+    const normalised = subdomain === null || subdomain === '' ? null : String(subdomain).trim().toLowerCase();
+    if (normalised !== (existing.subdomain || null)) {
+      if (normalised !== null) {
+        const v = validateSubdomain(normalised);
+        if (!v.ok) return res.status(400).json({ error: v.error });
+        const taken = db.prepare(
+          'SELECT id FROM forms WHERE subdomain = ? AND id != ?'
+        ).get(normalised, req.params.id);
+        if (taken) return res.status(409).json({ error: 'That subdomain is already in use by another form' });
+      }
+      try {
+        db.prepare('UPDATE forms SET subdomain = ?, updated_at = datetime(\'now\') WHERE id = ?').run(normalised, req.params.id);
+      } catch (err) {
+        if (err && err.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+          return res.status(409).json({ error: 'That subdomain is already in use' });
+        }
+        throw err;
+      }
+    }
+  }
 
   // Handle slug change separately: validate, check uniqueness, archive old slug.
   if (slug !== undefined && slug !== existing.slug) {

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -19,7 +19,10 @@ router.get('/', (req, res) => {
   for (const row of rows) {
     settings[row.key] = JSON.parse(row.value);
   }
-  res.json({ settings });
+  // Expose the operator-configured primary host so the form editor can render
+  // a correct subdomain preview ("<your-subdomain>.openflow.example.com").
+  const primaryHost = process.env.OPENFLOW_PRIMARY_HOST || null;
+  res.json({ settings, primaryHost });
 });
 
 // PUT /api/settings/:key — admin only

--- a/backend/src/utils/subdomain.js
+++ b/backend/src/utils/subdomain.js
@@ -1,0 +1,33 @@
+// Subdomain validation for per-form vanity hostnames.
+// Reuses the slug character grammar but applies a hostname-specific reserved list.
+
+const { SLUG_REGEX, MIN_LEN, MAX_LEN } = require('./slug');
+
+const RESERVED_SUBDOMAINS = new Set([
+  'www', 'api', 'admin', 'app', 'mail', 'ftp', 'dashboard',
+  'auth', 'login', 'logout', 'status', 'blog', 'docs', 'help',
+  'support', 'cdn', 'static', 'assets', 'embed', 'public',
+  'mx', 'smtp', 'imap', 'pop', 'pop3', 'ns', 'ns1', 'ns2',
+  'autodiscover', 'autoconfig', 'webmail',
+]);
+
+function validateSubdomain(sub) {
+  if (typeof sub !== 'string') {
+    return { ok: false, error: 'Subdomain must be a string' };
+  }
+  if (sub.length < MIN_LEN) {
+    return { ok: false, error: `Subdomain must be at least ${MIN_LEN} characters` };
+  }
+  if (sub.length > MAX_LEN) {
+    return { ok: false, error: `Subdomain must be at most ${MAX_LEN} characters` };
+  }
+  if (!SLUG_REGEX.test(sub)) {
+    return { ok: false, error: 'Subdomain may only contain lowercase letters, digits and hyphens (no leading, trailing, or consecutive hyphens)' };
+  }
+  if (RESERVED_SUBDOMAINS.has(sub)) {
+    return { ok: false, error: `"${sub}" is reserved and cannot be used as a subdomain` };
+  }
+  return { ok: true };
+}
+
+module.exports = { validateSubdomain, RESERVED_SUBDOMAINS };

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -49,6 +49,7 @@ function createTestApp() {
   const publicRoutes = require('../src/routes/public');
   const integrationRoutes = require('../src/routes/integrations');
   const analyticsRoutes = require('../src/routes/analytics');
+  const settingsRoutes = require('../src/routes/settings');
 
   app.use('/api/auth', authRoutes);
   app.use('/api/forms', formRoutes);
@@ -56,6 +57,7 @@ function createTestApp() {
   app.use('/api/public', publicRoutes);
   app.use('/api/integrations', integrationRoutes);
   app.use('/api/analytics', analyticsRoutes);
+  app.use('/api/settings', settingsRoutes);
 
   app.all('/api/*', (req, res) => {
     res.status(404).json({ error: 'API endpoint not found' });

--- a/backend/tests/subdomain.test.js
+++ b/backend/tests/subdomain.test.js
@@ -1,0 +1,294 @@
+const request = require('supertest');
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const { v4: uuid } = require('uuid');
+const { createTestApp } = require('./setup');
+const { validateSubdomain } = require('../src/utils/subdomain');
+const { extractSubdomain, createSubdomainMiddleware } = require('../src/middleware/subdomain');
+
+describe('Subdomain validation (unit)', () => {
+  it('accepts well-formed labels', () => {
+    expect(validateSubdomain('acme').ok).toBe(true);
+    expect(validateSubdomain('my-tenant').ok).toBe(true);
+    expect(validateSubdomain('a1b2c3').ok).toBe(true);
+  });
+
+  it('rejects short and long labels', () => {
+    expect(validateSubdomain('ab').ok).toBe(false);
+    expect(validateSubdomain('a'.repeat(61)).ok).toBe(false);
+  });
+
+  it('rejects uppercase, dots, underscores, leading/trailing hyphens', () => {
+    expect(validateSubdomain('Acme').ok).toBe(false);
+    expect(validateSubdomain('a.b').ok).toBe(false);
+    expect(validateSubdomain('foo_bar').ok).toBe(false);
+    expect(validateSubdomain('-acme').ok).toBe(false);
+    expect(validateSubdomain('acme-').ok).toBe(false);
+  });
+
+  it('rejects reserved subdomains', () => {
+    expect(validateSubdomain('www').ok).toBe(false);
+    expect(validateSubdomain('api').ok).toBe(false);
+    expect(validateSubdomain('admin').ok).toBe(false);
+    expect(validateSubdomain('mail').ok).toBe(false);
+  });
+
+  it('rejects non-string input', () => {
+    expect(validateSubdomain(123).ok).toBe(false);
+    expect(validateSubdomain(null).ok).toBe(false);
+  });
+});
+
+describe('extractSubdomain (unit)', () => {
+  it('returns null when hostname equals the primary host', () => {
+    expect(extractSubdomain('forms.example.com', 'forms.example.com')).toBeNull();
+  });
+
+  it('extracts a single-label prefix', () => {
+    expect(extractSubdomain('acme.forms.example.com', 'forms.example.com')).toBe('acme');
+  });
+
+  it('lowercases the result and matches case-insensitively', () => {
+    expect(extractSubdomain('ACME.FORMS.EXAMPLE.COM', 'forms.example.com')).toBe('acme');
+  });
+
+  it('returns null for unrelated hostnames', () => {
+    expect(extractSubdomain('evil.com', 'forms.example.com')).toBeNull();
+  });
+
+  it('rejects nested subdomains (more than one label deep)', () => {
+    expect(extractSubdomain('a.b.forms.example.com', 'forms.example.com')).toBeNull();
+  });
+
+  it('handles missing inputs', () => {
+    expect(extractSubdomain('', 'forms.example.com')).toBeNull();
+    expect(extractSubdomain('acme.forms.example.com', '')).toBeNull();
+  });
+});
+
+describe('PUT /api/forms/:id with subdomain (integration)', () => {
+  let app;
+  let cookie;
+  let userId;
+  let formId;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  beforeEach(async () => {
+    const db = require('../src/models/db').getDb();
+    db.pragma('foreign_keys = OFF');
+    db.exec('DELETE FROM slug_history');
+    db.pragma('foreign_keys = ON');
+
+    userId = uuid();
+    const hash = bcrypt.hashSync('userpass', 10);
+    db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?, ?, ?, ?)').run(userId, 'subdomain-tester@test.com', hash, 'user');
+
+    const login = await request(app).post('/api/auth/login').send({ email: 'subdomain-tester@test.com', password: 'userpass' });
+    cookie = login.headers['set-cookie'];
+
+    const created = await request(app)
+      .post('/api/forms')
+      .set('Cookie', cookie)
+      .send({ title: 'Test Form' });
+    formId = created.body.form.id;
+  });
+
+  it('sets a subdomain on the form', async () => {
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: 'acme' });
+    expect(res.status).toBe(200);
+    expect(res.body.form.subdomain).toBe('acme');
+  });
+
+  it('normalises uppercase and whitespace', async () => {
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: '  Acme  ' });
+    expect(res.status).toBe(200);
+    expect(res.body.form.subdomain).toBe('acme');
+  });
+
+  it('rejects invalid characters with 400', async () => {
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: 'in valid' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects reserved labels with 400', async () => {
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: 'www' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a subdomain claimed by another form with 409', async () => {
+    const other = await request(app).post('/api/forms').set('Cookie', cookie).send({ title: 'Other' });
+    await request(app)
+      .put(`/api/forms/${other.body.form.id}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: 'taken' });
+
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: 'taken' });
+    expect(res.status).toBe(409);
+  });
+
+  it('clears the subdomain when null is sent', async () => {
+    await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ subdomain: 'temp' });
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: null });
+    expect(res.status).toBe(200);
+    expect(res.body.form.subdomain).toBeNull();
+  });
+
+  it('clears the subdomain when empty string is sent', async () => {
+    await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ subdomain: 'temp' });
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ subdomain: '' });
+    expect(res.status).toBe(200);
+    expect(res.body.form.subdomain).toBeNull();
+  });
+
+  it('allows the same form to keep its subdomain across other updates', async () => {
+    await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ subdomain: 'acme' });
+    const res = await request(app)
+      .put(`/api/forms/${formId}`)
+      .set('Cookie', cookie)
+      .send({ title: 'New Title' });
+    expect(res.status).toBe(200);
+    expect(res.body.form.subdomain).toBe('acme');
+  });
+
+  it('exposes primaryHost in the settings response when set', async () => {
+    process.env.OPENFLOW_PRIMARY_HOST = 'forms.example.com';
+    const res = await request(app).get('/api/settings');
+    expect(res.status).toBe(200);
+    expect(res.body.primaryHost).toBe('forms.example.com');
+    delete process.env.OPENFLOW_PRIMARY_HOST;
+  });
+
+  it('returns null primaryHost when OPENFLOW_PRIMARY_HOST is not set', async () => {
+    delete process.env.OPENFLOW_PRIMARY_HOST;
+    const res = await request(app).get('/api/settings');
+    expect(res.status).toBe(200);
+    expect(res.body.primaryHost).toBeNull();
+  });
+});
+
+describe('Subdomain middleware (integration)', () => {
+  let app;
+  let formId;
+  let formSlug;
+  let userId;
+
+  beforeAll(() => {
+    process.env.OPENFLOW_PRIMARY_HOST = 'forms.example.com';
+
+    // Build a tiny app that only includes the middleware and stub handlers
+    // so we can inspect what gets routed through and what gets 404'd.
+    app = express();
+    app.set('trust proxy', true);
+    app.use(express.json());
+    app.use(createSubdomainMiddleware());
+
+    // Stand-ins for the real routes.
+    app.get('/api/forms', (req, res) => res.json({ ok: true, area: 'admin' }));
+    app.get('/api/public/form/:slug', (req, res) => res.json({ ok: true, area: 'public', slug: req.params.slug }));
+    app.get('*', (req, res) => {
+      if (req.subdomainForm) {
+        return res.type('html').send(`<!doctype html><script>window.__OPENFLOW_HOST_FORM__={"slug":"${req.subdomainForm.slug}"};</script>`);
+      }
+      res.type('html').send('<!doctype html><body>admin</body>');
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.OPENFLOW_PRIMARY_HOST;
+  });
+
+  beforeEach(() => {
+    const db = require('../src/models/db').getDb();
+    userId = uuid();
+    db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?, ?, ?, ?)').run(userId, 'sd-mw@test.com', bcrypt.hashSync('p', 10), 'user');
+
+    formId = uuid();
+    formSlug = `sub-${Date.now().toString(36)}`;
+    db.prepare(
+      'INSERT INTO forms (id, user_id, title, slug, subdomain, published) VALUES (?, ?, ?, ?, ?, 1)'
+    ).run(formId, userId, 'Acme Form', formSlug, 'acme');
+  });
+
+  it('passes through requests on the primary host unchanged', async () => {
+    const res = await request(app).get('/').set('Host', 'forms.example.com');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('admin');
+  });
+
+  it('serves form HTML with injected slug on a known subdomain', async () => {
+    const res = await request(app).get('/').set('Host', 'acme.forms.example.com');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain(`"slug":"${formSlug}"`);
+  });
+
+  it('serves the injected HTML for /index.html too (not the raw file)', async () => {
+    // Stand-in catch-all for this test ignores trailing path segments, so we
+    // only need to verify the rewrite happened by checking the response body.
+    const res = await request(app).get('/index.html').set('Host', 'acme.forms.example.com');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain(`"slug":"${formSlug}"`);
+  });
+
+  it('returns 404 plain text when no form claims the subdomain', async () => {
+    const res = await request(app).get('/').set('Host', 'nobody.forms.example.com');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the form exists but is unpublished', async () => {
+    const db = require('../src/models/db').getDb();
+    db.prepare('UPDATE forms SET published = 0 WHERE id = ?').run(formId);
+    const res = await request(app).get('/').set('Host', 'acme.forms.example.com');
+    expect(res.status).toBe(404);
+  });
+
+  it('blocks admin APIs on a subdomain', async () => {
+    const res = await request(app).get('/api/forms').set('Host', 'acme.forms.example.com');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Not available on this hostname');
+  });
+
+  it('allows public APIs on a subdomain', async () => {
+    const res = await request(app).get(`/api/public/form/${formSlug}`).set('Host', 'acme.forms.example.com');
+    expect(res.status).toBe(200);
+    expect(res.body.area).toBe('public');
+  });
+
+  it('treats www as the primary host (no subdomain)', async () => {
+    const res = await request(app).get('/').set('Host', 'www.forms.example.com');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('admin');
+  });
+
+  it('rejects nested subdomains as not-matching the pattern', async () => {
+    // a.b.forms.example.com does NOT route through subdomain logic, so the
+    // admin HTML is served (and admin APIs aren't blocked). This is the
+    // safe default — only single-label tenants are valid.
+    const res = await request(app).get('/').set('Host', 'a.b.forms.example.com');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('admin');
+  });
+});

--- a/docker-compose.subdomains.yml
+++ b/docker-compose.subdomains.yml
@@ -1,0 +1,45 @@
+# Overlay that adds Caddy as a wildcard-TLS reverse proxy in front of the
+# OpenFlow backend. Use together with the base file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.subdomains.yml up -d --build
+#
+# Required env vars (see .env.example):
+#   OPENFLOW_PRIMARY_HOST   — apex host you control (e.g. forms.example.com)
+#   CADDY_DNS_PROVIDER      — Caddy DNS provider plugin name (e.g. cloudflare, route53)
+#   CADDY_DNS_TOKEN         — API token for that provider, scoped to the zone
+#
+# The Caddy image must include the matching DNS plugin. The default
+# `caddy:2-alpine` does NOT — see https://hub.docker.com/_/caddy for the
+# `caddy/caddy:2-builder` recipe, or use a community image such as
+# `slothcroissant/caddy-cloudflaredns`.
+
+services:
+  app:
+    # Drop the public 3000 binding; Caddy is the only ingress.
+    ports: !reset []
+    expose:
+      - "3000"
+    environment:
+      - OPENFLOW_PRIMARY_HOST=${OPENFLOW_PRIMARY_HOST}
+
+  caddy:
+    image: ${CADDY_IMAGE:-caddy:2-alpine}
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - OPENFLOW_PRIMARY_HOST=${OPENFLOW_PRIMARY_HOST}
+      - CADDY_DNS_PROVIDER=${CADDY_DNS_PROVIDER}
+      - CADDY_DNS_TOKEN=${CADDY_DNS_TOKEN}
+      - CADDY_ACME_EMAIL=${CADDY_ACME_EMAIL:-admin@openflow.local}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - app
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,14 +6,28 @@ import FormView from './pages/FormView';
 import EmbedView from './pages/EmbedView';
 import './styles/global.css';
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+// If the backend served this page on a per-form subdomain it injects the
+// form identity into window.__OPENFLOW_HOST_FORM__. In that case we bypass
+// the normal admin SPA and serve only the form — every path renders FormView
+// for the bound slug.
+const hostForm = typeof window !== 'undefined' ? window.__OPENFLOW_HOST_FORM__ : null;
+
+const root = (
   <React.StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route path="/f/:slug" element={<FormView />} />
-        <Route path="/embed/:slug" element={<EmbedView />} />
-        <Route path="/*" element={<App />} />
-      </Routes>
+      {hostForm && hostForm.slug ? (
+        <Routes>
+          <Route path="*" element={<FormView slugProp={hostForm.slug} hostMode />} />
+        </Routes>
+      ) : (
+        <Routes>
+          <Route path="/f/:slug" element={<FormView />} />
+          <Route path="/embed/:slug" element={<EmbedView />} />
+          <Route path="/*" element={<App />} />
+        </Routes>
+      )}
     </BrowserRouter>
   </React.StrictMode>
 );
+
+ReactDOM.createRoot(document.getElementById('root')).render(root);

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -54,12 +54,18 @@ const EMOJI_CATEGORIES = {
 export default function FormEditor() {
   const { id } = useParams();
   const [form, setForm] = useState(null);
+  const [primaryHost, setPrimaryHost] = useState(null);
   const [loadError, setLoadError] = useState('');
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState('');
   const [activeTab, setActiveTab] = useState('steps');
   const [expandedStep, setExpandedStep] = useState(null);
+
+  useEffect(() => {
+    // Fetch site config once so we know whether subdomain hosting is configured.
+    api.getSettings().then(d => setPrimaryHost(d.primaryHost || null)).catch(() => {});
+  }, []);
 
   useEffect(() => {
     setLoadError('');
@@ -692,6 +698,14 @@ export default function FormEditor() {
             baseUrl={baseUrl}
           />
 
+          {primaryHost && (
+            <SubdomainEditor
+              form={form}
+              primaryHost={primaryHost}
+              onUpdated={(updated) => setForm(updated)}
+            />
+          )}
+
           <div className="input-group">
             <label>Direct Link</label>
             <input className="input" readOnly value={`${baseUrl}/f/${form.slug}`} onClick={e => { e.target.select(); navigator.clipboard?.writeText(e.target.value); }} />
@@ -1058,6 +1072,124 @@ function SlugEditor({ form, onUpdated, baseUrl }) {
           <span style={{ color: '#00B894' }}>URL updated. The previous URL will redirect to the new one.</span>
         ) : (
           <span style={{ color: '#999' }}>Lowercase letters, digits and hyphens. 3–60 characters.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ===========================
+   SubdomainEditor - bind a form to a vanity subdomain of the operator host
+   =========================== */
+const SUBDOMAIN_RESERVED = new Set([
+  'www', 'api', 'admin', 'app', 'mail', 'ftp', 'dashboard',
+  'auth', 'login', 'logout', 'status', 'blog', 'docs', 'help',
+  'support', 'cdn', 'static', 'assets', 'embed', 'public',
+  'mx', 'smtp', 'imap', 'pop', 'pop3', 'ns', 'ns1', 'ns2',
+  'autodiscover', 'autoconfig', 'webmail',
+]);
+
+function validateSubdomainClient(value) {
+  if (value.length < SLUG_MIN) return `At least ${SLUG_MIN} characters required.`;
+  if (value.length > SLUG_MAX) return `At most ${SLUG_MAX} characters allowed.`;
+  if (!SLUG_REGEX.test(value)) return 'Use only lowercase letters, digits, and hyphens (no leading/trailing or consecutive hyphens).';
+  if (SUBDOMAIN_RESERVED.has(value)) return `"${value}" is reserved and cannot be used as a subdomain.`;
+  return '';
+}
+
+function SubdomainEditor({ form, primaryHost, onUpdated }) {
+  const current = form.subdomain || '';
+  const [value, setValue] = useState(current);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => { setValue(form.subdomain || ''); }, [form.subdomain]);
+
+  const trimmed = value.trim().toLowerCase();
+  const dirty = trimmed !== (current || '');
+  const clientError = trimmed && dirty ? validateSubdomainClient(trimmed) : '';
+  const canSave = dirty && !clientError && !saving;
+
+  async function save(newValue) {
+    setError('');
+    setSaved(false);
+    setSaving(true);
+    try {
+      const { form: updated } = await api.updateForm(form.id, { subdomain: newValue || null });
+      onUpdated(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err.message || 'Failed to update subdomain');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const displayError = error || clientError;
+
+  return (
+    <div className="input-group">
+      <label>Custom subdomain (optional)</label>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'stretch' }}>
+        <input
+          className="input"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="acme"
+          spellCheck={false}
+          style={{
+            borderRadius: '8px 0 0 8px',
+            flex: 1,
+            fontFamily: 'monospace',
+          }}
+          onKeyDown={e => { if (e.key === 'Enter' && canSave) save(trimmed); }}
+        />
+        <div style={{
+          display: 'flex', alignItems: 'center', padding: '0 12px',
+          background: 'rgba(0,0,0,0.04)', border: '1px solid var(--border, #e0e0e0)',
+          borderLeft: 'none', borderRadius: '0 8px 8px 0',
+          color: 'var(--text-light)', fontSize: 14, whiteSpace: 'nowrap',
+        }}>
+          .{primaryHost}
+        </div>
+        <button
+          className="btn btn-primary"
+          onClick={() => save(trimmed)}
+          disabled={!canSave}
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          {saving ? 'Saving...' : 'Update'}
+        </button>
+        {current && !dirty && (
+          <button
+            className="btn btn-secondary"
+            onClick={() => { setValue(''); save(''); }}
+            disabled={saving}
+            style={{ whiteSpace: 'nowrap' }}
+          >
+            Remove
+          </button>
+        )}
+      </div>
+      <div style={{ marginTop: 6, minHeight: 18, fontSize: 12 }}>
+        {displayError ? (
+          <span style={{ color: '#E17055' }}>{displayError}</span>
+        ) : saved ? (
+          <span style={{ color: '#00B894' }}>
+            {trimmed ? `Your form is now reachable at https://${trimmed}.${primaryHost}` : 'Custom subdomain removed.'}
+          </span>
+        ) : current ? (
+          <span style={{ color: '#999' }}>
+            Live at <a href={`https://${current}.${primaryHost}`} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--primary)' }}>
+              https://{current}.{primaryHost}
+            </a>. Publish the form for it to be reachable.
+          </span>
+        ) : (
+          <span style={{ color: '#999' }}>
+            Serve this form at its own subdomain of <code>{primaryHost}</code>. Requires a wildcard DNS record to be configured by the operator.
+          </span>
         )}
       </div>
     </div>

--- a/frontend/src/pages/FormView.jsx
+++ b/frontend/src/pages/FormView.jsx
@@ -43,8 +43,9 @@ function CookieBanner({ form, onAccept, onDecline }) {
   );
 }
 
-export default function FormView() {
-  const { slug } = useParams();
+export default function FormView({ slugProp, hostMode = false }) {
+  const params = useParams();
+  const slug = slugProp || params.slug;
   const navigate = useNavigate();
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
@@ -65,15 +66,16 @@ export default function FormView() {
   useEffect(() => {
     api.getPublicForm(slug)
       .then(d => {
-        // If the requested slug is an old alias, swap the URL bar to the canonical one.
-        if (d.form && d.form.slug && d.form.slug !== slug) {
+        // On a per-form subdomain the canonical URL is just "/" — never
+        // navigate away from it even after a slug rename.
+        if (!hostMode && d.form && d.form.slug && d.form.slug !== slug) {
           navigate(`/f/${d.form.slug}`, { replace: true });
           return;
         }
         setForm(d.form);
       })
       .catch(e => setError(e.message));
-  }, [slug, navigate]);
+  }, [slug, navigate, hostMode]);
 
   // Determine cookie consent state once form is loaded
   useEffect(() => {


### PR DESCRIPTION
## Summary

Phase 2 of the custom-URL feature: each form can now be served on its own subdomain of an operator-controlled parent host. Visitors at `https://acme.forms.example.com` see Acme's form on a clean URL; the form continues to be reachable at the existing `/f/<slug>` and `/embed/<slug>` paths too.

The cost on the operator: one wildcard DNS record + one wildcard TLS certificate. Renewals are automatic via Caddy + Let's Encrypt DNS-01.

## How it works

- **Subdomain on the form**: new nullable, unique `forms.subdomain` column. Validation reuses the slug grammar (`[a-z0-9-]{3,60}`) with a hostname-specific reserved-word blocklist (`www, api, admin, mail, …`).
- **Backend middleware** (`backend/src/middleware/subdomain.js`): when `OPENFLOW_PRIMARY_HOST` is set and a request arrives on `<sub>.<primary-host>` (single label, not `www`), it resolves the form claiming that subdomain, attaches it to `req.subdomainForm`, and 404s any admin API path (`/api/auth`, `/api/forms`, `/api/submissions`, `/api/integrations`, `/api/analytics`, `/api/settings`). Public APIs and static assets pass through. If no form claims the subdomain, returns a clean 404.
- **HTML injection** (`backend/src/index.js`): the SPA catch-all reads `index.html` once (cached), and on subdomain requests injects `<script>window.__OPENFLOW_HOST_FORM__={"slug":"...","id":"..."};</script>` before `</head>`. `express.static` now has `index: false` so it can't bypass the catch-all on `/`. Direct hits to `/index.html` are rewritten back to `/` so they go through injection too.
- **Frontend boot** (`frontend/src/main.jsx`): when the injected variable is present, the SPA renders only `FormView` for the bound slug — every path matches, no admin routes are ever loaded. `FormView` gained a `slugProp` + `hostMode` so it accepts the injected slug and skips the slug-rename URL-rewrite (canonical URL on a subdomain is always `/`).
- **Editor UI**: `FormEditor.jsx` exposes a new "Custom subdomain (optional)" field next to the existing slug editor — only when the server reports a configured `primaryHost` via the extended `/api/settings` response.
- **Wildcard TLS**: new `Caddyfile` + opt-in `docker-compose.subdomains.yml` overlay add a Caddy reverse proxy that obtains one `*.<primary-host>` cert via the DNS-01 ACME challenge and proxies all traffic to the backend. One cert per deployment, automatic renewal, no per-tenant verification step.

## What changed

```
.env.example                              | + OPENFLOW_PRIMARY_HOST, CADDY_DNS_PROVIDER, CADDY_DNS_TOKEN
Caddyfile                                 | new — wildcard + apex reverse proxy
docker-compose.subdomains.yml             | new — overlay with Caddy service
README.md                                 | new "Custom Subdomains" section + v0.10.0 badge
CHANGELOG.md                              | 0.10.0 entry
backend/package.json                      | 0.10.0
backend/src/index.js                      | + subdomain middleware + HTML injection + trust proxy
backend/src/middleware/subdomain.js       | new — host parsing + admin-path 404
backend/src/utils/subdomain.js            | new — validator + hostname reserved list
backend/src/models/db.js                  | + subdomain column migration + partial unique index
backend/src/routes/forms.js               | accepts/clears subdomain on PUT
backend/src/routes/settings.js            | exposes primaryHost in response
backend/tests/setup.js                    | wires settings routes into createTestApp
backend/tests/subdomain.test.js           | 30 new tests (validator, host parsing, PUT, middleware)
frontend/main.jsx                         | host-mode bypass (subdomain SPA = FormView only)
frontend/pages/FormView.jsx               | accepts slugProp + hostMode; skips canonical redirect on host mode
frontend/pages/FormEditor.jsx             | new SubdomainEditor component + primaryHost fetch
```

## Test plan

- [x] `cd backend && npx jest --runInBand --forceExit tests/subdomain.test.js` — 30 new tests pass
- [x] `cd backend && npx jest --runInBand --forceExit` — 79/84 pass; the 5 failures are pre-existing in `auth.test.js` and `validation.test.js` and are unaffected by this PR
- [x] `cd frontend && npm run build` — clean build
- [ ] Manual (requires a real domain): set `OPENFLOW_PRIMARY_HOST=forms.example.com`, point `*.forms.example.com` at the server, configure `CADDY_DNS_PROVIDER` + `CADDY_DNS_TOKEN`, run with `docker compose -f docker-compose.yml -f docker-compose.subdomains.yml up -d --build`, set a form's subdomain to `acme`, then verify:
  - [ ] `https://acme.forms.example.com` serves the form, URL bar stays at `/`
  - [ ] Caddy obtained a wildcard cert (logs)
  - [ ] `https://acme.forms.example.com/dashboard` → admin paths 404
  - [ ] `https://acme.forms.example.com/api/forms` → 404 JSON
  - [ ] `https://nobody.forms.example.com` → 404
  - [ ] `https://forms.example.com` (apex) → admin UI loads normally
  - [ ] Slug rename of acme's form doesn't change the subdomain URL

Phase 1 (editable slug) merged in #57 remains the baseline — this PR builds on it.

https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4)_