### PR TITLE
fix: orphaned slug_history blocks reuse; tighten trust-proxy (v0.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.10.1] - 2026-05-23
+
+### Fixed
+- **Deleted forms locked their old slugs forever** — `DELETE /api/forms/:id` did not clean up the `slug_history` table, so rows referencing a deleted form remained behind and caused the rename-conflict check to return 409 for any other form trying to reuse those slugs. The delete transaction now removes the form's history rows.
+- **`trust proxy` was set unconditionally** — Setting `trust proxy: true` when no reverse proxy is in front allows any client to spoof `req.ip` via `X-Forwarded-For`, which affects in-memory rate limiting. The setting is now enabled only when `OPENFLOW_PRIMARY_HOST` is configured (the same condition that triggers subdomain routing, which requires Caddy in front).
+
 ## [0.10.0] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
 ### 🔌 Embedding & Tracking
 - **iframe Embed** — Drop forms into any landing page (with auto-resize)
+- **Editable URL Slug** — Rename a form's URL anytime (`/f/spring-launch` instead of the auto-generated 8-char code); old links keep working via 301-style redirect
+- **Custom Subdomain** — Host each form on its own subdomain of a domain you control (e.g. `acme.forms.example.com`), backed by a single wildcard TLS cert
 - **🏷️ GTM Integration** — Google Tag Manager per form, with step and submit events
 - **WordPress Plugin** — Shortcode `[openflow]`, WPBakery element, and Gutenberg block
 
@@ -257,6 +259,17 @@ window.addEventListener('message', function(e) {
 ```
 
 Also available as a **WPBakery element** and **Gutenberg block**.
+
+### Custom URL Slug
+
+Every form is reachable at `/f/<slug>`. Open the form's **Embed** tab to rename the slug from the auto-generated 8-character code to anything memorable (e.g. `/f/spring-launch`). Rules:
+
+- Lowercase letters, digits, hyphens. 3–60 characters.
+- No leading/trailing or consecutive hyphens.
+- Reserved labels (`admin`, `api`, `login`, `embed`, `f`, `dashboard`, …) are rejected.
+- Must be unique across all forms.
+
+Previously shared URLs keep working: when you change a slug, the old one is recorded in a history table and visits to it transparently load the form at its current slug. The browser URL bar is updated to the canonical address so subsequent shares use the new URL.
 
 ### Custom Subdomains
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.10.0
+# 🌊 OpenFlow v0.10.1
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -16,9 +16,12 @@ const { createSubdomainMiddleware } = require('./middleware/subdomain');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Trust X-Forwarded-* headers so req.hostname reflects the Host header
-// that Caddy (or any other reverse proxy) saw from the client.
-app.set('trust proxy', true);
+// Trust X-Forwarded-* headers only when this deployment is fronted by a
+// reverse proxy (subdomain routing requires one). Trusting in unproxied
+// setups would let any client spoof req.ip via X-Forwarded-For.
+if (process.env.OPENFLOW_PRIMARY_HOST) {
+  app.set('trust proxy', 1);
+}
 
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json({ limit: '50mb' }));

--- a/backend/src/routes/forms.js
+++ b/backend/src/routes/forms.js
@@ -174,6 +174,9 @@ router.delete('/:id', (req, res) => {
     db.prepare('DELETE FROM analytics_events WHERE form_id = ?').run(formId);
     db.prepare('DELETE FROM integrations WHERE form_id = ?').run(formId);
     db.prepare('DELETE FROM submissions WHERE form_id = ?').run(formId);
+    // Without this, orphaned rows lock the deleted form's old slugs out
+    // of reuse — other forms hit a 409 from the history-conflict check.
+    db.prepare('DELETE FROM slug_history WHERE form_id = ?').run(formId);
     db.prepare('DELETE FROM forms WHERE id = ?').run(formId);
   });
   deleteForm(req.params.id);

--- a/backend/tests/slug.test.js
+++ b/backend/tests/slug.test.js
@@ -161,6 +161,25 @@ describe('Slug editing & history (integration)', () => {
     expect(res.status).toBe(409);
   });
 
+  it('frees a deleted form\'s old slugs for reuse by other forms', async () => {
+    // Rename a form to give it some history, then delete it. Another form
+    // should be able to claim those previously-used slugs.
+    await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'will-be-deleted' });
+    await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'also-history' });
+    await request(app).delete(`/api/forms/${formId}`).set('Cookie', cookie);
+
+    const db = require('../src/models/db').getDb();
+    const remaining = db.prepare('SELECT COUNT(*) as n FROM slug_history WHERE form_id = ?').get(formId);
+    expect(remaining.n).toBe(0);
+
+    const other = await request(app).post('/api/forms').set('Cookie', cookie).send({ title: 'Reusing' });
+    const reclaim = await request(app)
+      .put(`/api/forms/${other.body.form.id}`)
+      .set('Cookie', cookie)
+      .send({ slug: 'will-be-deleted' });
+    expect(reclaim.status).toBe(200);
+  });
+
   it('lets a form reclaim its own previous slug', async () => {
     await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'alpha' });
     await request(app).put(`/api/forms/${formId}`).set('Cookie', cookie).send({ slug: 'beta' });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Two issues found during a code-quality pass on the merged custom-URL feature (PRs #57 + #58):

### Bug: deleted forms locked their old slugs forever

When a form was deleted, the corresponding `slug_history` rows were left behind. The next time another form tried to rename to one of those old slugs, the history-conflict check returned 409 — even though the original form was gone and no live form claimed the slug.

```js
// backend/src/routes/forms.js — DELETE transaction
db.prepare('DELETE FROM slug_history WHERE form_id = ?').run(formId);
```

Added a regression test (`backend/tests/slug.test.js`) that creates a form, renames it twice (giving it two history rows), deletes it, then verifies another form can claim the old slug.

### Quality: trust-proxy was unconditional

`app.set('trust proxy', true)` runs at startup whether or not a reverse proxy actually fronts the app. In deployments without Caddy, this lets any client spoof `req.ip` via the `X-Forwarded-For` header — which affects the in-memory rate limiter in `backend/src/models/rateLimit.js`.

Now scoped to: only enabled when `OPENFLOW_PRIMARY_HOST` is set (the same env var that turns on subdomain routing, which already requires Caddy in front). Default deployments stay strict.

## Test plan

- [x] `cd backend && npx jest --runInBand --forceExit tests/slug.test.js` — 23/23 pass, includes the new `frees a deleted form's old slugs for reuse by other forms` test
- [x] `cd backend && npx jest --runInBand --forceExit` — 80/85 pass (5 unrelated pre-existing failures)

## Things I considered but decided NOT to change

A few items came up in review that turned out to be non-issues on closer inspection:
- **TOCTOU on concurrent slug renames** — the `UPDATE` already catches `SQLITE_CONSTRAINT_UNIQUE` and returns 409, so the race is handled at the DB layer.
- **`isAdminPath` prefix collision** — the implementation is `p === prefix || p.startsWith(prefix + '/')`, which correctly excludes `/api/auth-export` etc.
- **Static `/index.HTML` bypass on a subdomain** — only `/index.html` exists on disk (case-sensitive FS); other casings fall through to the catch-all and get injected normally.
- **Migration ordering between ADD COLUMN and CREATE UNIQUE INDEX** — `CREATE INDEX IF NOT EXISTS` runs unconditionally on every startup, so a crash between the two statements self-heals on the next boot.

https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4)_