### PR TITLE
docs: expand custom subdomain section with per-form steps and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,24 +273,82 @@ Previously shared URLs keep working: when you change a slug, the old one is reco
 
 ### Custom Subdomains
 
-Serve each form on its own subdomain of a host you control (e.g. `acme.forms.example.com`). Every form gets a vanity URL that's friendlier than `/f/<slug>` and looks tenant-owned.
+Serve each form on its own subdomain of a host you control (e.g. `acme.forms.example.com`). Every form gets a vanity URL that's friendlier than `/f/<slug>` and looks tenant-owned. A form keeps its existing `/f/<slug>` and `/embed/<slug>` paths in parallel — the subdomain is just an additional, prettier entry point.
 
-**One-time operator setup:**
+#### How it works
 
-1. Set `OPENFLOW_PRIMARY_HOST` to the apex you control (e.g. `forms.example.com`) in `.env`.
-2. Add a wildcard DNS record at your provider: `*.forms.example.com → <your server IP>` (A/AAAA).
-3. Choose a DNS provider that has a Caddy plugin (Cloudflare, Route53, DigitalOcean, …). Create an API token scoped to the zone and set `CADDY_DNS_PROVIDER` and `CADDY_DNS_TOKEN` in `.env`.
-4. Use the subdomain-aware compose overlay:
+Caddy fronts the app on ports 80/443 and acquires **one wildcard TLS certificate** for `*.<primary-host>` via Let's Encrypt's DNS-01 challenge. That single cert covers every form on every subdomain — there is no per-tenant verification step or on-demand TLS dance. When a request lands on `<sub>.<primary-host>`, the backend looks up which form claimed that subdomain, blocks any admin API paths with a 404, and injects the form's identity into `index.html`. The frontend then boots in form-only mode: every URL renders that form and admin routes are unreachable.
+
+#### 1. Operator setup (one-time)
+
+Pick an apex host you control (e.g. `forms.example.com`) and a DNS provider with a Caddy plugin (Cloudflare, Route53, DigitalOcean, Hetzner, Gandi, …).
+
+**a. Configure DNS.** At your registrar, add a wildcard A/AAAA record:
+
+```
+*.forms.example.com   A   <your-server-ip>
+forms.example.com     A   <your-server-ip>
+```
+
+Wait for propagation — `dig +short '*.forms.example.com'` (or any subdomain you pick) should resolve to your server. Cloudflare proxy (orange-cloud) must be **disabled** for the wildcard, otherwise Caddy can't see the real Host header.
+
+**b. Create a scoped DNS API token.** The token only needs **edit** rights for that one zone — it's used by Caddy to add a temporary `_acme-challenge` TXT record during cert issuance.
+
+**c. Fill in `.env`:**
+
+```bash
+OPENFLOW_PRIMARY_HOST=forms.example.com
+CADDY_DNS_PROVIDER=cloudflare        # or route53, digitalocean, hetzner, ...
+CADDY_DNS_TOKEN=your-scoped-api-token
+CADDY_ACME_EMAIL=you@example.com     # optional, used by Let's Encrypt for expiry warnings
+
+# Caddy image with the matching DNS plugin built in. The default caddy:2-alpine
+# does NOT ship plugins — either use a community image or build your own.
+CADDY_IMAGE=slothcroissant/caddy-cloudflaredns:latest
+```
+
+**d. Bring it up with the subdomain-aware overlay:**
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.subdomains.yml up -d --build
 ```
 
-Caddy fronts the app on ports 80/443 and provisions a **single wildcard certificate** via Let's Encrypt's DNS-01 challenge. The cert covers every form forever; renewal is automatic.
+The overlay removes the public `3000:3000` binding (Caddy is the only ingress now) and adds the Caddy service that owns ports 80/443.
 
-> **Note**: the default `caddy:2-alpine` image does not include DNS provider plugins. Either use a community image such as `slothcroissant/caddy-cloudflaredns` (set `CADDY_IMAGE` in `.env`) or build your own with `xcaddy`.
+**e. Verify.** Tail Caddy until you see `certificate obtained successfully` for `*.<primary-host>`:
 
-**Per form:** open the form's Embed tab → enter a subdomain label (lowercase letters, digits, hyphens; 3–60 chars; not `www`, `api`, `admin`, etc.). Publish the form. Visitors at `https://<label>.<your-host>` see the form; admin paths return 404 on the subdomain.
+```bash
+docker compose logs -f caddy
+```
+
+Then hit the apex in a browser → admin UI should load with a valid TLS cert.
+
+> **DNS providers without a Caddy plugin** — your options are (a) build a Caddy image with `xcaddy` that includes a plugin for your provider, (b) put any other reverse proxy in front and skip the overlay, or (c) terminate TLS at a CDN (e.g. Cloudflare proxied DNS with a uploaded origin cert) and bypass the cert-issuance flow entirely.
+
+#### 2. Per-form usage
+
+For each form you want on its own subdomain:
+
+1. Open the form in the editor and go to the **Embed** tab.
+2. In **Custom subdomain (optional)**, type a label — `acme`, `widgets-inc`, `summer-promo` — and click **Update**.
+   - Rules: 3–60 chars, lowercase letters, digits and hyphens only. No leading/trailing or consecutive hyphens. Common reserved labels (`www`, `api`, `admin`, `mail`, etc.) are rejected.
+3. **Publish** the form (it must be live to be served on the subdomain).
+4. The success message links to the live URL: `https://<label>.<your-primary-host>`.
+
+To change the subdomain later, just edit the field and click **Update** — the form is reachable at the new label immediately. To detach the subdomain entirely, clear the field and click **Update** (or use the **Remove** button when the value matches what's saved). Note that — unlike the editable slug — subdomain changes are **not** archived: the old subdomain stops working immediately. Use it for stable tenant-style URLs, not for marketing campaign renames.
+
+A form's `/f/<slug>` and `/embed/<slug>` URLs on the primary host always keep working in parallel.
+
+#### Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Caddy logs show `no DNS module registered with name "cloudflare"` (or similar) | The Caddy image doesn't include the DNS plugin. Use a community image or build with `xcaddy`. |
+| Cert issuance hangs or times out | DNS API token lacks edit rights for the zone, or the wildcard record isn't visible yet. Verify with `dig`. |
+| `acme: error: 429 :: urn:ietf:params:acme:error:rateLimited` | You hit Let's Encrypt's rate limit during testing. Caddy's data volume persists certs across restarts — don't `docker compose down -v` between attempts. |
+| Subdomain returns the admin UI instead of the form | The form isn't published, or its `subdomain` field doesn't match the label. Confirm via `GET /api/forms/:id` on the admin host. |
+| Visiting the subdomain shows "Form not found" | The subdomain is unclaimed, or the form was deleted/unpublished. |
+| Admin works on `https://forms.example.com` but `https://forms.example.com:3000` is also reachable | You didn't use the overlay file — the base compose still publishes port 3000. Use both `-f` flags in `docker compose up`. |
 
 ---
 


### PR DESCRIPTION
## Summary

The previous Custom Subdomains section in the README was operator-heavy: four numbered DNS/Caddy setup steps followed by a single sentence for form owners. This restructures it into four clearer subsections so both audiences land where they need to:

- **How it works** — short architecture brief (wildcard cert, host-header lookup, HTML injection, form-only SPA boot)
- **Operator setup (one-time)** — full worked example with concrete DNS records, the `.env` block filled in, a verification step (`docker compose logs -f caddy`), and a note covering DNS providers without a Caddy plugin
- **Per-form usage** — the Embed-tab workflow as numbered steps, plus the rename / detach behaviour. Calls out the important gotcha that subdomain changes are **not** archived (unlike slug changes) — old subdomain stops working immediately, so it's for stable tenant URLs, not campaign renames.
- **Troubleshooting** — table of the most common failures (missing DNS plugin, ACME rate limit, unpublished form returning admin UI, port-3000 leak from forgetting the overlay).

No code changes. README only.

## Test plan

- [x] Render-checked the section by reading the diff; no Markdown errors expected
- [ ] Manual: load the rendered README on GitHub after merge to confirm the table renders and the numbered subsections sit at the right heading level

https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4)_