### PR TITLE
docs: add clickable table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # 🌊 OpenFlow v0.10.1
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
+## 📚 Table of Contents
+
+- [✨ Features](#-features)
+- [🚀 Quick Start](#-quick-start)
+- [🔄 Updating](#-updating)
+- [⚙️ Configuration](#-configuration)
+- [🏗️ Architecture](#-architecture)
+- [📋 Field Types](#-field-types)
+- [🔗 Integrations](#-integrations)
+- [📈 Analytics](#-analytics)
+- [🏷️ GTM Events](#-gtm-events)
+- [🔌 Embedding](#-embedding)
+  - [Simple iFrame](#simple-iframe)
+  - [iFrame with Auto-Resize](#iframe-with-auto-resize)
+  - [WordPress](#wordpress)
+  - [Custom URL Slug](#custom-url-slug)
+  - [Custom Subdomains](#custom-subdomains)
+- [📡 API Endpoints](#-api-endpoints)
+- [🧑‍💻 Development](#-development)
+- [🗺️ Roadmap](#-roadmap)
+- [📄 License](#-license)
 
 ## ✨ Features
 


### PR DESCRIPTION
## Summary

Adds a clickable table of contents under the README's tagline. 13 top-level sections plus 5 subsections under Embedding (where the new custom-URL features live) are now one click away from the top.

## Anchor encoding gotcha

GitHub's slugger strips emojis **and** the U+FE0F variation selector. That means `## ⚙️ Configuration` resolves to `#-configuration`, not `#️-configuration`. I caught this with an `od -c` byte check after the first draft — four anchors had embedded VS-16 in the URL portion that would have 404'd silently. They're now clean (variation selector kept in the visible label only).

## Test plan

- [x] `od -c` confirms anchors contain only ASCII (no U+FE0F bytes inside `(#...)`)
- [ ] Manual: load rendered README on GitHub, click every TOC link, confirm each scrolls to the right section

https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkQt6Ki6JFg64Gd635uqB4)_