### PR TITLE
fix: reassign forms to admin after cross-deployment restore (v0.11.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.11.2] - 2026-06-16
+
+### Fixed
+- **Restored forms invisible after cross-deployment restore** — When an admin restored a backup onto a fresh deployment where their account had a different UUID, all their forms were orphaned (the `user_id` still pointed to the old UUID). The restore logic now detects this ID mismatch and reassigns the forms to the acting admin's current UUID automatically.
+
 ## [0.11.1] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.11.1
+# 🌊 OpenFlow v0.11.2
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.10.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.10.1",
+      "version": "0.11.2",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/models/backup.js
+++ b/backend/src/models/backup.js
@@ -186,6 +186,14 @@ function restoreBackup(db, rawBackup, options = {}) {
       // their original credentials with the admin role.
       let adminPreserved = false;
       if (preserveUser && preserveUser.id && preserveUser.email) {
+        // Capture the backup's user id for this email before deleting it.
+        // When restoring to a fresh deployment the backup user may have a
+        // different id than the acting admin (UUIDs are regenerated on first
+        // sign-up). Their forms would otherwise be orphaned because the
+        // forms.user_id still points to the now-deleted backup id.
+        const backupUser = db.prepare('SELECT id FROM users WHERE email = ?').get(preserveUser.email);
+        const backupUserId = backupUser ? backupUser.id : null;
+
         db.prepare('DELETE FROM users WHERE id = ? OR email = ?').run(
           preserveUser.id,
           preserveUser.email
@@ -199,6 +207,16 @@ function restoreBackup(db, rawBackup, options = {}) {
           'admin',
           preserveUser.created_at || new Date().toISOString()
         );
+
+        // If the backup had a matching user under a different id, their forms
+        // are now orphaned. Reassign them so the admin can see them immediately.
+        if (backupUserId && backupUserId !== preserveUser.id) {
+          db.prepare('UPDATE forms SET user_id = ? WHERE user_id = ?').run(
+            preserveUser.id,
+            backupUserId
+          );
+        }
+
         adminPreserved = true;
       }
 

--- a/backend/tests/backup.test.js
+++ b/backend/tests/backup.test.js
@@ -152,6 +152,38 @@ describe('Admin backup & restore', () => {
       expect(admins.n).toBe(1);
     });
 
+    it('reassigns forms to the acting admin when the backup used a different user id', async () => {
+      // Simulate restoring to a fresh deployment: the admin signs up with the
+      // same email but gets a new UUID. The backup contains forms owned by the
+      // old UUID. After restore those forms must be visible to the new admin.
+      const { adminId } = seedUsers();
+      const cookie = await login(app, 'admin@test.com', 'adminpass');
+      const db = getDb();
+
+      const oldAdminId = uuid(); // id the admin had in the source deployment
+      const formId = uuid();
+      const backup = {
+        openflow_backup: true,
+        version: 1,
+        tables: {
+          users: [
+            { id: oldAdminId, email: 'admin@test.com', password_hash: bcrypt.hashSync('adminpass', 10), role: 'admin' },
+          ],
+          forms: [
+            { id: formId, user_id: oldAdminId, title: 'Migrated Form', slug: 'migrated-form', published: 0, theme: '{}', integrations: '{}', fields: '[]' },
+          ],
+        },
+      };
+
+      const res = await request(app).post('/api/admin/restore').set('Cookie', cookie).send(backup);
+      expect(res.status).toBe(200);
+
+      // The form must now be owned by the acting admin's current id.
+      const form = db.prepare('SELECT user_id FROM forms WHERE id = ?').get(formId);
+      expect(form).toBeDefined();
+      expect(form.user_id).toBe(adminId);
+    });
+
     it('rejects a non-OpenFlow file', async () => {
       seedUsers();
       const cookie = await login(app, 'admin@test.com', 'adminpass');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug**: When restoring a backup onto a fresh deployment, the admin's forms were invisible because the backup's `user_id` (old UUID) no longer matched the acting admin's current UUID.
- **Fix**: `restoreBackup()` now detects this mismatch (same email, different UUID) and runs `UPDATE forms SET user_id = <new-id> WHERE user_id = <old-id>` before returning.
- **Test**: New regression test in `backup.test.js` verifies forms are reassigned end-to-end.

## Root cause

The admin-preservation logic deletes any backup user matching the acting admin's email, then re-inserts the admin with their *current* UUID. But forms owned by the email-matching backup user still carried the *old* UUID as `user_id` — now pointing at a deleted row. Since `GET /api/forms` filters with `WHERE user_id = ?`, the admin saw zero forms.

## Test plan

- [ ] Run `npm test -- backup.test.js` in `backend/` — all 12 tests pass
- [ ] Create a backup on deployment A, restore it on deployment B (different admin UUID), verify forms appear immediately in the dashboard

https://claude.ai/code/session_01J4eAq164wYbQZi9u4R8uM7
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4eAq164wYbQZi9u4R8uM7)_