### PR TITLE
Form cloning, combine-questions, new logo & admin UI refresh (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.12.0] - 2026-06-18
+
+### Added
+- **Clone a form** — A new **Duplicate** action on the Forms dashboard copies a form's structure (questions, theme, end screen) and its integrations in one click via `POST /api/forms/:id/clone`. The copy is created as a draft with a fresh URL and a "(Copy)" title; submissions and analytics are never carried over, and copied integrations are created **disabled** so a clone can't send leads to live destinations until you review and re-enable them.
+- **Combine two questions into one step** — Questions can now be merged so two fields (e.g. email + phone) appear on a single screen. Use the **Combine** buttons in the editor to group a question with the one above or below it, and **Split** to separate them again — fully reversible. Combined steps validate every field before advancing, and each field keeps its own column in the submissions table, CSV export and integrations.
+
+### Changed
+- **Refreshed, more consistent admin UI** — Page headers, alert banners, and empty/loading states are now shared components for a consistent look across every admin page; content is centred on wide screens, the active sidebar item is clearer, hardcoded colours were replaced with theme tokens (better dark mode), and the form-title field no longer overflows on small screens.
+- **New OpenFlow logo mark** — A custom "flow" icon replaces the old glyph in the sidebar and login screen, and ships as the browser favicon.
+
 ## [0.11.2] - 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.11.2
+# 🌊 OpenFlow v0.12.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.11.2",
+      "version": "0.12.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -1,5 +1,6 @@
 const nodemailer = require('nodemailer');
 const { google } = require('googleapis');
+const { flattenFields } = require('../utils/steps');
 
 // ──────────────────────────────────────────
 // Run all integrations for a form submission
@@ -84,13 +85,13 @@ async function runEmail(config, formId, formTitle, data, steps) {
     auth: smtp_user ? { user: smtp_user, pass: smtp_pass } : undefined,
   });
 
-  // Build a nice HTML table from submission data
-  const rows = (steps || []).map(step => {
-    let val = data[step.id];
+  // Build a nice HTML table from submission data (one row per field, groups expanded)
+  const rows = flattenFields(steps).map(field => {
+    let val = data[field.id];
     if (val === undefined || val === null) val = '-';
     if (typeof val === 'object') val = JSON.stringify(val);
     if (Array.isArray(val)) val = val.join(', ');
-    return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:#555;">${step.label || step.question || step.id}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;">${val}</td></tr>`;
+    return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:#555;">${field.label || field.question || field.id}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;">${val}</td></tr>`;
   }).join('');
 
   const html = `
@@ -123,7 +124,7 @@ async function runGoogleSheetsAppsScript(config, formId, formTitle, data, steps)
     formId,
     formTitle,
     data,
-    fields: (steps || []).map(s => ({ id: s.id, label: s.label || s.question || s.id })),
+    fields: flattenFields(steps).map(s => ({ id: s.id, label: s.label || s.question || s.id })),
     timestamp: new Date().toISOString(),
   };
 
@@ -172,7 +173,7 @@ async function runGoogleSheets(config, formId, data, steps) {
   });
 
   if (!headerRes.data.values || headerRes.data.values.length === 0) {
-    const headers = ['Timestamp', ...(steps || []).map(s => s.label || s.question || s.id)];
+    const headers = ['Timestamp', ...flattenFields(steps).map(s => s.label || s.question || s.id)];
     await sheets.spreadsheets.values.update({
       spreadsheetId: spreadsheet_id,
       range: `${sheet_name}!A1`,
@@ -181,10 +182,10 @@ async function runGoogleSheets(config, formId, data, steps) {
     });
   }
 
-  // Append the submission row
+  // Append the submission row (one cell per field, groups expanded)
   const row = [
     new Date().toISOString(),
-    ...(steps || []).map(s => {
+    ...flattenFields(steps).map(s => {
       let val = data[s.id];
       if (val === undefined || val === null) return '';
       if (typeof val === 'object') return JSON.stringify(val);

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -94,12 +94,18 @@ router.get('/:formId', (req, res) => {
       conversionRate: views > 0 ? Math.round((completions / views) * 100) : 0,
       startRate: views > 0 ? Math.round((starts / views) * 100) : 0,
     },
-    stepDropoff: stepEvents.map(se => ({
-      stepIndex: se.step_index,
-      stepId: se.step_id,
-      label: steps[se.step_index]?.label || steps[se.step_index]?.question || `Step ${se.step_index + 1}`,
-      sessions: se.sessions,
-    })),
+    stepDropoff: stepEvents.map(se => {
+      const s = steps[se.step_index];
+      const label = s?.type === 'group' && Array.isArray(s.fields)
+        ? s.fields.map(f => f.label || f.question).filter(Boolean).join(' + ') || `Step ${se.step_index + 1}`
+        : s?.label || s?.question || `Step ${se.step_index + 1}`;
+      return {
+        stepIndex: se.step_index,
+        stepId: se.step_id,
+        label,
+        sessions: se.sessions,
+      };
+    }),
     daily,
   });
 });

--- a/backend/src/routes/forms.js
+++ b/backend/src/routes/forms.js
@@ -68,6 +68,53 @@ router.post('/', (req, res) => {
   res.status(201).json({ form });
 });
 
+// Clone (duplicate) a form
+router.post('/:id/clone', (req, res) => {
+  const db = getDb();
+  const source = db.prepare('SELECT * FROM forms WHERE id = ? AND user_id = ?').get(req.params.id, req.userId);
+  if (!source) return res.status(404).json({ error: 'Form not found' });
+
+  const newId = uuid();
+  const newSlug = nanoid();
+
+  const cloneForm = db.transaction(() => {
+    // steps/end_screen/theme are already JSON strings on the source row — copy verbatim.
+    // The clone is always a draft with a fresh slug and no subdomain.
+    db.prepare(`
+      INSERT INTO forms (id, user_id, title, slug, steps, end_screen, theme, gtm_id, published)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)
+    `).run(
+      newId, req.userId,
+      `${source.title} (Copy)`,
+      newSlug,
+      source.steps, source.end_screen, source.theme, source.gtm_id || ''
+    );
+
+    // Copy integrations, but leave them disabled so the clone can't send leads
+    // to live destinations until the user reviews and re-enables them.
+    const integrations = db.prepare('SELECT type, config FROM integrations WHERE form_id = ?').all(req.params.id);
+    const insertIntegration = db.prepare(
+      'INSERT INTO integrations (id, form_id, type, enabled, config) VALUES (?, ?, ?, 0, ?)'
+    );
+    for (const integ of integrations) {
+      insertIntegration.run(uuid(), newId, integ.type, integ.config);
+    }
+  });
+  cloneForm();
+
+  const form = db.prepare('SELECT * FROM forms WHERE id = ?').get(newId);
+  try {
+    form.steps = JSON.parse(form.steps);
+    form.end_screen = JSON.parse(form.end_screen);
+    form.theme = JSON.parse(form.theme);
+  } catch {
+    return res.status(500).json({ error: 'Failed to read cloned form' });
+  }
+  // Match the list-row shape so the dashboard can prepend it without a refetch.
+  form.submission_count = 0;
+  res.status(201).json({ form });
+});
+
 // Update form
 router.put('/:id', (req, res) => {
   const db = getDb();

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -1,6 +1,7 @@
 const { Router } = require('express');
 const { getDb } = require('../models/db');
 const { checkRateLimit } = require('../models/rateLimit');
+const { flattenFields } = require('../utils/steps');
 const { v4: uuid } = require('uuid');
 
 const router = Router();
@@ -60,10 +61,10 @@ router.post('/form/:slug/submit', async (req, res) => {
     return res.status(400).json({ error: 'Invalid submission data' });
   }
 
-  // Basic validation
-  for (const step of steps) {
-    if (step.required && (!data[step.id] || String(data[step.id]).trim() === '')) {
-      return res.status(400).json({ error: `Field "${step.label || step.id}" is required` });
+  // Basic validation (descend into combined "group" steps so each field is checked)
+  for (const field of flattenFields(steps)) {
+    if (field.required && (!data[field.id] || String(data[field.id]).trim() === '')) {
+      return res.status(400).json({ error: `Field "${field.label || field.id}" is required` });
     }
   }
 

--- a/backend/src/routes/submissions.js
+++ b/backend/src/routes/submissions.js
@@ -1,6 +1,7 @@
 const { Router } = require('express');
 const { getDb } = require('../models/db');
 const { authMiddleware } = require('../middleware/auth');
+const { flattenFields } = require('../utils/steps');
 
 const router = Router();
 
@@ -40,11 +41,12 @@ router.get('/:formId/export', (req, res) => {
     'SELECT * FROM submissions WHERE form_id = ? ORDER BY created_at DESC'
   ).all(req.params.formId);
 
-  const steps = JSON.parse(form.steps);
-  const headers = ['Submitted At', ...steps.map(s => s.label || s.question || s.id)];
+  // Flatten combined "group" steps to one column per underlying field.
+  const fields = flattenFields(JSON.parse(form.steps));
+  const headers = ['Submitted At', ...fields.map(f => f.label || f.question || f.id)];
   const rows = submissions.map(s => {
     const data = JSON.parse(s.data);
-    return [s.created_at, ...steps.map(step => data[step.id] ?? '')];
+    return [s.created_at, ...fields.map(f => data[f.id] ?? '')];
   });
 
   const csv = [headers, ...rows].map(row =>

--- a/backend/src/utils/steps.js
+++ b/backend/src/utils/steps.js
@@ -1,0 +1,22 @@
+// Helpers for working with a form's `steps` array.
+//
+// A step is normally a single field. Two adjacent questions can be combined
+// into one screen ("step") in the editor; such a step has the shape
+//   { id, type: 'group', fields: [ fieldA, fieldB ] }
+// where each entry in `fields` is an ordinary field keeping its own id. Every
+// downstream consumer (validation, CSV export, integrations, ...) cares about
+// the individual leaf fields, so it flattens groups first via this helper.
+
+function flattenFields(steps) {
+  const out = [];
+  for (const step of steps || []) {
+    if (step && step.type === 'group' && Array.isArray(step.fields)) {
+      for (const field of step.fields) out.push(field);
+    } else if (step) {
+      out.push(step);
+    }
+  }
+  return out;
+}
+
+module.exports = { flattenFields };

--- a/backend/tests/forms.test.js
+++ b/backend/tests/forms.test.js
@@ -1,0 +1,126 @@
+const request = require('supertest');
+const bcrypt = require('bcryptjs');
+const { v4: uuid } = require('uuid');
+const { createTestApp } = require('./setup');
+
+function getDb() {
+  return require('../src/models/db').getDb();
+}
+
+function seedUser() {
+  const db = getDb();
+  const userId = uuid();
+  db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?, ?, ?, ?)')
+    .run(userId, 'owner@test.com', bcrypt.hashSync('ownerpass', 10), 'admin');
+  return userId;
+}
+
+async function login(app) {
+  const res = await request(app).post('/api/auth/login').send({ email: 'owner@test.com', password: 'ownerpass' });
+  return res.headers['set-cookie'];
+}
+
+describe('Form clone', () => {
+  let app;
+  beforeAll(() => { app = createTestApp(); });
+
+  it('requires authentication', async () => {
+    const res = await request(app).post('/api/forms/some-id/clone');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when cloning a form the user does not own', async () => {
+    seedUser();
+    const cookie = await login(app);
+    const res = await request(app).post('/api/forms/does-not-exist/clone').set('Cookie', cookie);
+    expect(res.status).toBe(404);
+  });
+
+  it('clones structure as a draft with a new slug and a "(Copy)" title', async () => {
+    const userId = seedUser();
+    const db = getDb();
+    const formId = uuid();
+    const steps = [{ id: 'name', type: 'text', label: 'Name', question: 'Your name?' }];
+    db.prepare('INSERT INTO forms (id, user_id, title, slug, steps, published) VALUES (?, ?, ?, ?, ?, 1)')
+      .run(formId, userId, 'Lead Form', 'lead-form', JSON.stringify(steps));
+    // A submission on the original must NOT carry over to the clone.
+    db.prepare('INSERT INTO submissions (id, form_id, data) VALUES (?, ?, ?)')
+      .run(uuid(), formId, JSON.stringify({ name: 'Ada' }));
+
+    const cookie = await login(app);
+    const res = await request(app).post(`/api/forms/${formId}/clone`).set('Cookie', cookie);
+
+    expect(res.status).toBe(201);
+    const clone = res.body.form;
+    expect(clone.id).not.toBe(formId);
+    expect(clone.slug).not.toBe('lead-form');
+    expect(clone.title).toBe('Lead Form (Copy)');
+    expect(clone.published).toBe(0);
+    expect(clone.steps).toEqual(steps);
+    expect(clone.submission_count).toBe(0);
+
+    const cloneSubs = db.prepare('SELECT COUNT(*) AS n FROM submissions WHERE form_id = ?').get(clone.id);
+    expect(cloneSubs.n).toBe(0);
+  });
+
+  it('copies integrations but creates them disabled', async () => {
+    const userId = seedUser();
+    const db = getDb();
+    const formId = uuid();
+    db.prepare('INSERT INTO forms (id, user_id, title, slug, steps) VALUES (?, ?, ?, ?, ?)')
+      .run(formId, userId, 'With Integrations', 'with-integrations', '[]');
+    db.prepare('INSERT INTO integrations (id, form_id, type, enabled, config) VALUES (?, ?, ?, 1, ?)')
+      .run(uuid(), formId, 'webhook', JSON.stringify({ url: 'https://example.com/hook' }));
+
+    const cookie = await login(app);
+    const res = await request(app).post(`/api/forms/${formId}/clone`).set('Cookie', cookie);
+    expect(res.status).toBe(201);
+
+    const cloned = db.prepare('SELECT type, enabled, config FROM integrations WHERE form_id = ?').all(res.body.form.id);
+    expect(cloned).toHaveLength(1);
+    expect(cloned[0].type).toBe('webhook');
+    expect(cloned[0].enabled).toBe(0);
+    expect(JSON.parse(cloned[0].config).url).toBe('https://example.com/hook');
+  });
+});
+
+describe('Combined "group" steps', () => {
+  let app;
+  beforeAll(() => { app = createTestApp(); });
+
+  function seedGroupForm() {
+    const db = getDb();
+    const userId = uuid();
+    db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?, ?, ?, ?)')
+      .run(userId, 'g@test.com', bcrypt.hashSync('x', 10), 'admin');
+    const formId = uuid();
+    const steps = [
+      {
+        id: 'group_1', type: 'group', fields: [
+          { id: 'email', type: 'email', label: 'Email', required: true },
+          { id: 'phone', type: 'phone', label: 'Phone', required: true },
+        ],
+      },
+    ];
+    db.prepare('INSERT INTO forms (id, user_id, title, slug, steps, published) VALUES (?, ?, ?, ?, ?, 1)')
+      .run(formId, userId, 'Combined', 'combined', JSON.stringify(steps));
+    return { formId };
+  }
+
+  it('validates every field inside a combined step on submit', async () => {
+    seedGroupForm();
+    const res = await request(app)
+      .post('/api/public/form/combined/submit')
+      .send({ data: { email: 'a@b.com' } }); // phone missing
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Phone/);
+  });
+
+  it('accepts a submission that fills every field in the combined step', async () => {
+    seedGroupForm();
+    const res = await request(app)
+      .post('/api/public/form/combined/submit')
+      .send({ data: { email: 'a@b.com', phone: '+1 555' } });
+    expect(res.status).toBe(201);
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6C5CE7"/>
+      <stop offset="1" stop-color="#A29BFE"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="9" fill="url(#g)"/>
+  <path d="M6 12c3.2-3.4 6.6-3.4 10 0s6.8 3.4 10 0" stroke="#fff" stroke-width="2.4" stroke-linecap="round" opacity=".95"/>
+  <path d="M6 17c3.2-3.4 6.6-3.4 10 0s6.8 3.4 10 0" stroke="#fff" stroke-width="2.4" stroke-linecap="round" opacity=".75"/>
+  <path d="M6 22c3.2-3.4 6.6-3.4 10 0s6.8 3.4 10 0" stroke="#fff" stroke-width="2.4" stroke-linecap="round" opacity=".5"/>
+</svg>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,8 +9,9 @@ import Users from './pages/Users';
 import Analytics from './pages/Analytics';
 import Settings from './pages/Settings';
 import Backup from './pages/Backup';
+import { LogoMark, Loading } from './components/AdminUI';
 
-const APP_VERSION = '0.11.1';
+const APP_VERSION = '0.12.0';
 
 function getInitialTheme() {
   return localStorage.getItem('of_theme') || 'auto';
@@ -48,7 +49,7 @@ export default function App() {
   const themeIcon = theme === 'dark' ? '🌙' : theme === 'light' ? '☀️' : '🖥️';
   const themeLabel = theme === 'dark' ? 'Dark' : theme === 'light' ? 'Light' : 'Auto';
 
-  if (loading) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
+  if (loading) return <Loading />;
 
   if (!user) {
     return <Login onLogin={(u) => { setUser(u); navigate('/'); }} />;
@@ -64,7 +65,7 @@ export default function App() {
   return (
     <div className="admin-layout">
       <aside className="admin-sidebar">
-        <h1><span className="logo-icon">&#9830;</span>OpenFlow</h1>
+        <h1><LogoMark size={28} className="logo-mark" />OpenFlow</h1>
         <nav>
           <Link to="/" className={location.pathname === '/' ? 'active' : ''}>Forms</Link>
           <Link to="/analytics" className={location.pathname === '/analytics' ? 'active' : ''}>Analytics</Link>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -34,6 +34,7 @@ export const api = {
   getForm: (id) => request(`/forms/${id}`),
   createForm: (data) => request('/forms', { method: 'POST', body: JSON.stringify(data) }),
   updateForm: (id, data) => request(`/forms/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  cloneForm: (id) => request(`/forms/${id}/clone`, { method: 'POST' }),
   deleteForm: (id) => request(`/forms/${id}`, { method: 'DELETE' }),
 
   getSubmissions: (formId, page = 1) => request(`/submissions/${formId}?page=${page}`),

--- a/frontend/src/components/AdminUI.jsx
+++ b/frontend/src/components/AdminUI.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Shared admin UI primitives. These replace the ad-hoc inline blocks that were
+ * duplicated (and had drifted) across the admin pages: page headers, alert
+ * banners, loading and empty states. Keeping them here ensures one consistent
+ * look and a single place to restyle.
+ */
+
+export function PageHeader({ title, subtitle, backTo, backLabel = '← Back', children }) {
+  return (
+    <div className="page-header">
+      <div className="page-header-titles">
+        {backTo && <Link to={backTo} className="back-link">{backLabel}</Link>}
+        <h2>{title}</h2>
+        {subtitle && <p className="page-subtitle">{subtitle}</p>}
+      </div>
+      {children && <div className="page-header-actions">{children}</div>}
+    </div>
+  );
+}
+
+export function Alert({ type = 'error', children, style }) {
+  if (!children) return null;
+  return <div className={`alert alert-${type}`} style={style}>{children}</div>;
+}
+
+export function Loading({ label = 'Loading…' }) {
+  return <div className="loading-state">{label}</div>;
+}
+
+export function EmptyState({ title, message, children }) {
+  return (
+    <div className="card empty-state">
+      {title && <h3>{title}</h3>}
+      {message && <p>{message}</p>}
+      {children}
+    </div>
+  );
+}
+
+/**
+ * OpenFlow brand mark — three flowing waves on the brand gradient tile.
+ * Each instance gets a unique gradient id so multiple marks can coexist.
+ */
+export function LogoMark({ size = 28, className = '' }) {
+  const uid = React.useId();
+  const gradId = `of-grad-${uid}`;
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#6C5CE7" />
+          <stop offset="1" stopColor="#A29BFE" />
+        </linearGradient>
+      </defs>
+      <rect width="32" height="32" rx="9" fill={`url(#${gradId})`} />
+      <path d="M6 12c3.2-3.4 6.6-3.4 10 0s6.8 3.4 10 0" stroke="#fff" strokeWidth="2.4" strokeLinecap="round" opacity="0.95" />
+      <path d="M6 17c3.2-3.4 6.6-3.4 10 0s6.8 3.4 10 0" stroke="#fff" strokeWidth="2.4" strokeLinecap="round" opacity="0.75" />
+      <path d="M6 22c3.2-3.4 6.6-3.4 10 0s6.8 3.4 10 0" stroke="#fff" strokeWidth="2.4" strokeLinecap="round" opacity="0.5" />
+    </svg>
+  );
+}

--- a/frontend/src/components/FormRenderer.css
+++ b/frontend/src/components/FormRenderer.css
@@ -169,6 +169,21 @@
   margin-top: 32px;
 }
 
+/* Combined "group" steps: two questions stacked on one screen */
+.form-group-field + .form-group-field {
+  border-top: 1px solid rgba(127, 127, 127, 0.15);
+  padding-top: 24px;
+}
+
+.form-group-field .step-question.group-subquestion {
+  font-size: clamp(18px, 2.6vw, 22px);
+  margin-bottom: 8px;
+}
+
+.form-group-field .step-field {
+  margin-top: 16px;
+}
+
 .step-error {
   color: #E17055;
   font-size: 14px;

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -48,6 +48,45 @@ const FIELD_TYPES = {
   'file-upload': FileUploadInput,
 };
 
+// Validate a single field's value. Returns an error string, or null if valid.
+// Shared by normal steps and the sub-fields of a combined "group" step.
+function validateField(field, value, locale) {
+  const empty = value === undefined || value === null || value === ''
+    || (Array.isArray(value) && value.length === 0);
+  if (field.required && empty) return locale.errorRequired;
+  if (field.type === 'email' && value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) return locale.errorEmail;
+  if (field.type === 'website' && value && !/^https?:\/\/.+\..+/.test(value)) return locale.errorUrl;
+  if (field.type === 'consent' && field.required && !value) return locale.errorConsent;
+  if ((field.type === 'address' || field.type === 'contact') && field.required) {
+    const c = value || {};
+    if (!c.street || !c.postalCode || !c.city) return locale.errorAddress;
+  }
+  return null;
+}
+
+// Renders the sub-fields of a combined ("group") step stacked vertically.
+// Each sub-field keeps its own id, so answers stay keyed per field.
+function GroupInput({ step, answers, setFieldAnswer }) {
+  return (
+    <div className="form-group-fields">
+      {(step.fields || []).map((field, idx) => {
+        const Field = FIELD_TYPES[field.type] || TextInput;
+        const display = applyPricingFilter(field, answers);
+        return (
+          <div key={field.id} className="form-group-field" style={idx > 0 ? { marginTop: 24 } : undefined}>
+            {field.label && <span className="step-label">{field.label}</span>}
+            {field.question && <h3 className="step-question group-subquestion">{field.question}</h3>}
+            {field.description && <p className="step-description">{field.description}</p>}
+            <div className="step-field">
+              <Field step={display} value={answers[field.id]} onChange={(v) => setFieldAnswer(field.id, v)} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 // Generate a unique session ID for analytics
 function getSessionId() {
   let sid = sessionStorage.getItem('of_sid');
@@ -149,41 +188,26 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
     return () => { document.body.style.background = prev; };
   }, [formBg]);
 
-  function setAnswer(value) {
-    setAnswers(prev => ({ ...prev, [step.id]: value }));
+  function setFieldAnswer(fieldId, value) {
+    setAnswers(prev => ({ ...prev, [fieldId]: value }));
     setError('');
   }
 
-  function canProceed() {
-    if (!step) return false;
-    if (!step.required) return true;
-    const val = answers[step.id];
-    if (val === undefined || val === null || val === '') return false;
-    if (Array.isArray(val) && val.length === 0) return false;
-    return true;
+  function setAnswer(value) {
+    setFieldAnswer(step.id, value);
+  }
+
+  // A combined ("group") step validates each of its sub-fields; a normal step
+  // validates itself.
+  function stepFields(s) {
+    return s.type === 'group' && Array.isArray(s.fields) ? s.fields : [s];
   }
 
   const next = useCallback(function next() {
-    if (!canProceed()) {
-      setError(locale.errorRequired);
-      return;
-    }
-    if (step.type === 'email' && answers[step.id] && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(answers[step.id])) {
-      setError(locale.errorEmail);
-      return;
-    }
-    if (step.type === 'website' && answers[step.id] && !/^https?:\/\/.+\..+/.test(answers[step.id])) {
-      setError(locale.errorUrl);
-      return;
-    }
-    if (step.type === 'consent' && step.required && !answers[step.id]) {
-      setError(locale.errorConsent);
-      return;
-    }
-    if ((step.type === 'address' || step.type === 'contact') && step.required) {
-      const c = answers[step.id] || {};
-      if (!c.street || !c.postalCode || !c.city) {
-        setError(locale.errorAddress);
+    for (const field of stepFields(step)) {
+      const err = validateField(field, answers[field.id], locale);
+      if (err) {
+        setError(err);
         return;
       }
     }
@@ -347,30 +371,44 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
       <div className="form-content">
         <div className={`form-step ${direction === 'forward' ? 'slide-in-forward' : 'slide-in-back'}`} key={currentStep}>
-          {step.label && <span className="step-label">{step.label}</span>}
-          <h2 className="step-question">{step.question}</h2>
-          {step.description && <p className="step-description">{step.description}</p>}
+          {step.type === 'group' ? (
+            <>
+              <GroupInput step={step} answers={answers} setFieldAnswer={setFieldAnswer} />
+              {(buttonPosition === 'below-input' || buttonPosition === 'inline') && (
+                <div className={buttonPosition === 'below-input' ? 'form-below-input-actions' : 'form-inline-actions'}>
+                  {nextButton}
+                  {enterHint}
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              {step.label && <span className="step-label">{step.label}</span>}
+              <h2 className="step-question">{step.question}</h2>
+              {step.description && <p className="step-description">{step.description}</p>}
 
-          <div className="step-field">
-            <FieldComponent
-              step={displayStep}
-              value={answers[step.id]}
-              onChange={setAnswer}
-            />
-            {buttonPosition === 'below-input' && (
-              <div className="form-below-input-actions">
-                {nextButton}
-                {enterHint}
+              <div className="step-field">
+                <FieldComponent
+                  step={displayStep}
+                  value={answers[step.id]}
+                  onChange={setAnswer}
+                />
+                {buttonPosition === 'below-input' && (
+                  <div className="form-below-input-actions">
+                    {nextButton}
+                    {enterHint}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
 
-          {/* Inline button (below input but after question) */}
-          {buttonPosition === 'inline' && (
-            <div className="form-inline-actions">
-              {nextButton}
-              {enterHint}
-            </div>
+              {/* Inline button (below input but after question) */}
+              {buttonPosition === 'inline' && (
+                <div className="form-inline-actions">
+                  {nextButton}
+                  {enterHint}
+                </div>
+              )}
+            </>
           )}
 
           {/* GDPR consent on last step */}

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../api';
+import { PageHeader, Alert, EmptyState, Loading } from '../components/AdminUI';
 
 export default function Analytics() {
   const [forms, setForms] = useState([]);
@@ -29,24 +30,19 @@ export default function Analytics() {
     }
   }, [selected, days]);
 
-  if (loading) return <div style={{ padding: 40, textAlign: 'center' }}>Loading analytics...</div>;
+  if (loading) return <Loading label="Loading analytics…" />;
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
-        <h2>Analytics</h2>
+      <PageHeader title="Analytics">
         <select className="input" style={{ width: 'auto' }} value={days} onChange={e => setDays(Number(e.target.value))}>
           <option value={7}>Last 7 days</option>
           <option value={30}>Last 30 days</option>
           <option value={90}>Last 90 days</option>
         </select>
-      </div>
+      </PageHeader>
 
-      {error && (
-        <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
-          {error}
-        </div>
-      )}
+      <Alert type="error">{error}</Alert>
 
       {/* Overview cards */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 16, marginBottom: 24 }}>
@@ -80,10 +76,7 @@ export default function Analytics() {
       </div>
 
       {forms.length === 0 && !error && (
-        <div className="card" style={{ textAlign: 'center', padding: 60 }}>
-          <h3>No analytics data yet</h3>
-          <p style={{ color: '#636E72' }}>Publish a form and share it to start collecting analytics.</p>
-        </div>
+        <EmptyState title="No analytics data yet" message="Publish a form and share it to start collecting analytics." />
       )}
 
       {/* Detail view */}
@@ -94,9 +87,9 @@ export default function Analytics() {
           {/* Funnel */}
           <div className="card" style={{ marginBottom: 16 }}>
             <h4 style={{ marginBottom: 16 }}>Conversion Funnel</h4>
-            <FunnelBar label="Views" value={detail.summary.views} max={detail.summary.views} color="#6C5CE7" />
+            <FunnelBar label="Views" value={detail.summary.views} max={detail.summary.views} color="var(--primary)" />
             <FunnelBar label="Started" value={detail.summary.starts} max={detail.summary.views} color="#0984E3" />
-            <FunnelBar label="Completed" value={detail.summary.completions} max={detail.summary.views} color="#00B894" />
+            <FunnelBar label="Completed" value={detail.summary.completions} max={detail.summary.views} color="var(--success)" />
             <div style={{ display: 'flex', gap: 24, marginTop: 16, fontSize: 14, color: 'var(--text-light)' }}>
               <span>Start Rate: <strong>{detail.summary.startRate}%</strong></span>
               <span>Conversion: <strong>{detail.summary.conversionRate}%</strong></span>
@@ -113,7 +106,7 @@ export default function Analytics() {
                   label={`${i + 1}. ${step.label}`}
                   value={step.sessions}
                   max={detail.stepDropoff[0]?.sessions || 1}
-                  color={i === detail.stepDropoff.length - 1 ? '#00B894' : '#6C5CE7'}
+                  color={i === detail.stepDropoff.length - 1 ? 'var(--success)' : 'var(--primary)'}
                 />
               ))}
             </div>
@@ -167,15 +160,15 @@ function DailyChart({ data }) {
           const d = days[day];
           return (
             <div key={day} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }} title={`${day}\nViews: ${d.views}\nStarts: ${d.starts}\nCompletions: ${d.completions}`}>
-              <div style={{ width: '100%', maxWidth: 24, background: '#6C5CE7', borderRadius: '3px 3px 0 0', height: `${(d.views / maxVal) * 100}%`, minHeight: d.views > 0 ? 4 : 0, opacity: 0.3 }} />
-              <div style={{ width: '100%', maxWidth: 24, background: '#00B894', borderRadius: '3px 3px 0 0', height: `${(d.completions / maxVal) * 100}%`, minHeight: d.completions > 0 ? 4 : 0, marginTop: -1 * ((d.views / maxVal) * 100) + '%', position: 'relative' }} />
+              <div style={{ width: '100%', maxWidth: 24, background: 'var(--primary)', borderRadius: '3px 3px 0 0', height: `${(d.views / maxVal) * 100}%`, minHeight: d.views > 0 ? 4 : 0, opacity: 0.3 }} />
+              <div style={{ width: '100%', maxWidth: 24, background: 'var(--success)', borderRadius: '3px 3px 0 0', height: `${(d.completions / maxVal) * 100}%`, minHeight: d.completions > 0 ? 4 : 0, marginTop: -1 * ((d.views / maxVal) * 100) + '%', position: 'relative' }} />
             </div>
           );
         })}
       </div>
       <div style={{ display: 'flex', gap: 16, fontSize: 12, color: 'var(--text-light)' }}>
-        <span><span style={{ display: 'inline-block', width: 8, height: 8, background: '#6C5CE7', borderRadius: 2, marginRight: 4, opacity: 0.3 }} />Views</span>
-        <span><span style={{ display: 'inline-block', width: 8, height: 8, background: '#00B894', borderRadius: 2, marginRight: 4 }} />Completions</span>
+        <span><span style={{ display: 'inline-block', width: 8, height: 8, background: 'var(--primary)', borderRadius: 2, marginRight: 4, opacity: 0.3 }} />Views</span>
+        <span><span style={{ display: 'inline-block', width: 8, height: 8, background: 'var(--success)', borderRadius: 2, marginRight: 4 }} />Completions</span>
       </div>
     </div>
   );

--- a/frontend/src/pages/Backup.jsx
+++ b/frontend/src/pages/Backup.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { api } from '../api';
+import { PageHeader, Alert } from '../components/AdminUI';
 
 export default function Backup() {
   const [info, setInfo] = useState(null);
@@ -92,19 +93,16 @@ export default function Backup() {
 
   return (
     <div>
-      <div style={{ marginBottom: 24 }}>
-        <h2>Backup &amp; Restore</h2>
-        <p style={{ color: 'var(--text-light)', fontSize: 14, margin: '4px 0 0' }}>
-          Download a full snapshot of your database, or restore from a previous backup.
-          Restoring also migrates older backups to the current format automatically.
-        </p>
-      </div>
+      <PageHeader
+        title="Backup & Restore"
+        subtitle="Download a full snapshot of your database, or restore from a previous backup. Restoring also migrates older backups to the current format automatically."
+      />
 
-      {error && <div className="card" style={{ marginBottom: 16, borderLeft: '4px solid var(--danger)', color: 'var(--danger)' }}>{error}</div>}
-      {notice && <div className="card" style={{ marginBottom: 16, borderLeft: '4px solid var(--success, #00b894)', color: 'var(--success, #00b894)' }}>{notice}</div>}
+      <Alert type="error">{error}</Alert>
+      <Alert type="success">{notice}</Alert>
 
       <div className="card" style={{ marginBottom: 16 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+        <div className="section-header">
           <span style={{ fontSize: 20 }}>💾</span>
           <div>
             <h3 style={{ margin: 0 }}>Download Backup</h3>
@@ -130,7 +128,7 @@ export default function Backup() {
       </div>
 
       <div className="card" style={{ borderLeft: '4px solid var(--danger)' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+        <div className="section-header">
           <span style={{ fontSize: 20 }}>♻️</span>
           <div>
             <h3 style={{ margin: 0 }}>Restore from Backup</h3>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { api } from '../api';
+import { PageHeader, Alert, EmptyState, Loading } from '../components/AdminUI';
 
 export default function Dashboard() {
   const [forms, setForms] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [cloningId, setCloningId] = useState(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -32,6 +34,19 @@ export default function Dashboard() {
     }
   }
 
+  async function cloneForm(id) {
+    setError('');
+    setCloningId(id);
+    try {
+      const { form } = await api.cloneForm(id);
+      setForms(prev => [form, ...prev]);
+    } catch (err) {
+      setError(err.message || 'Failed to clone form');
+    } finally {
+      setCloningId(null);
+    }
+  }
+
   async function deleteForm(id) {
     const form = forms.find(f => f.id === id);
     if (!form) return;
@@ -52,64 +67,64 @@ export default function Dashboard() {
     }
   }
 
-  if (loading) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
+  if (loading) return <Loading />;
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
-        <h2>Forms</h2>
+      <PageHeader title="Forms">
         <button className="btn btn-primary" onClick={createForm}>+ New Form</button>
-      </div>
+      </PageHeader>
 
-      {error && (
-        <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
-          {error}
-        </div>
-      )}
+      <Alert type="error">{error}</Alert>
 
       {forms.length === 0 ? (
-        <div className="card" style={{ textAlign: 'center', padding: 60 }}>
-          <h3 style={{ marginBottom: 8 }}>No forms yet</h3>
-          <p style={{ color: '#636E72', marginBottom: 24 }}>Create your first lead generation form.</p>
+        <EmptyState title="No forms yet" message="Create your first lead generation form.">
           <button className="btn btn-primary" onClick={createForm}>Create Form</button>
-        </div>
+        </EmptyState>
       ) : (
-        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Title</th>
-                <th>Status</th>
-                <th>Responses</th>
-                <th>Created</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {forms.map(form => (
-                <tr key={form.id}>
-                  <td>
-                    <Link to={`/forms/${form.id}`} style={{ color: 'inherit', textDecoration: 'none', fontWeight: 600 }}>
-                      {form.title}
-                    </Link>
-                  </td>
-                  <td>
-                    <span className={`badge ${form.published ? 'badge-published' : 'badge-draft'}`}>
-                      {form.published ? 'Live' : 'Draft'}
-                    </span>
-                  </td>
-                  <td>{form.submission_count}</td>
-                  <td style={{ fontSize: 13, color: '#636E72' }}>{new Date(form.created_at).toLocaleDateString('en')}</td>
-                  <td style={{ textAlign: 'right' }}>
-                    <Link to={`/forms/${form.id}/submissions`} className="btn btn-sm btn-secondary" style={{ marginRight: 8, textDecoration: 'none' }}>
-                      Responses
-                    </Link>
-                    <button className="btn btn-sm btn-danger" onClick={() => deleteForm(form.id)}>Delete</button>
-                  </td>
+        <div className="card" style={{ padding: 0 }}>
+          <div className="table-wrap">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>Status</th>
+                  <th>Responses</th>
+                  <th>Created</th>
+                  <th></th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {forms.map(form => (
+                  <tr key={form.id}>
+                    <td>
+                      <Link to={`/forms/${form.id}`} style={{ color: 'inherit', textDecoration: 'none', fontWeight: 600 }}>
+                        {form.title}
+                      </Link>
+                    </td>
+                    <td>
+                      <span className={`badge ${form.published ? 'badge-published' : 'badge-draft'}`}>
+                        {form.published ? 'Live' : 'Draft'}
+                      </span>
+                    </td>
+                    <td>{form.submission_count}</td>
+                    <td style={{ fontSize: 13, color: 'var(--text-light)' }}>{new Date(form.created_at).toLocaleDateString('en')}</td>
+                    <td>
+                      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                        <Link to={`/forms/${form.id}/submissions`} className="btn btn-sm btn-secondary" style={{ textDecoration: 'none' }}>
+                          Responses
+                        </Link>
+                        <button className="btn btn-sm btn-secondary" onClick={() => cloneForm(form.id)} disabled={cloningId === form.id}>
+                          {cloningId === form.id ? 'Duplicating…' : 'Duplicate'}
+                        </button>
+                        <button className="btn btn-sm btn-danger" onClick={() => deleteForm(form.id)}>Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -164,18 +164,46 @@ export default function FormEditor() {
     else if (expandedStep === target) setExpandedStep(index);
   }
 
+  // Merge an adjacent pair of single questions into one combined "group" step
+  // (max two questions per step). dir = -1 combines with the question above,
+  // dir = +1 with the one below. Reversible via splitGroup.
+  function combineSteps(index, dir) {
+    const topIndex = dir === -1 ? index - 1 : index;
+    const a = form.steps[topIndex];
+    const b = form.steps[topIndex + 1];
+    if (!a || !b || a.type === 'group' || b.type === 'group') return;
+    const group = { id: `group_${Date.now()}`, type: 'group', fields: [a, b] };
+    // Lift a sub-field condition up to the group so visibility logic still
+    // applies while combined; the original is preserved for a lossless split.
+    if (a.condition || b.condition) group.condition = a.condition || b.condition;
+    const steps = [...form.steps];
+    steps.splice(topIndex, 2, group);
+    setForm({ ...form, steps });
+    setExpandedStep(topIndex);
+  }
+
+  // Split a combined step back into its two separate questions.
+  function splitGroup(index) {
+    const group = form.steps[index];
+    if (!group || group.type !== 'group') return;
+    const steps = [...form.steps];
+    steps.splice(index, 1, ...(group.fields || []));
+    setForm({ ...form, steps });
+    setExpandedStep(index);
+  }
+
   const baseUrl = window.location.origin;
 
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
         <div>
-          <Link to="/" style={{ color: '#636E72', textDecoration: 'none', fontSize: 13 }}>&larr; Back</Link>
+          <Link to="/" className="back-link">&larr; Back</Link>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 8 }}>
             <input
               value={form.title}
               onChange={e => setForm({ ...form, title: e.target.value })}
-              style={{ fontSize: 24, fontWeight: 700, border: 'none', background: 'none', padding: 0, outline: 'none', width: 400, color: 'var(--text)' }}
+              style={{ fontSize: 24, fontWeight: 700, border: 'none', background: 'none', padding: 0, outline: 'none', flex: 1, minWidth: 0, maxWidth: 480, color: 'var(--text)' }}
             />
             <span className={`badge ${form.published ? 'badge-published' : 'badge-draft'}`}>
               {form.published ? 'Live' : 'Draft'}
@@ -183,8 +211,8 @@ export default function FormEditor() {
           </div>
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          {saved && <span style={{ color: '#00B894', fontSize: 13 }}>Saved!</span>}
-          {saveError && <span style={{ color: '#E17055', fontSize: 13 }}>{saveError}</span>}
+          {saved && <span style={{ color: 'var(--success)', fontSize: 13 }}>Saved!</span>}
+          {saveError && <span style={{ color: 'var(--danger)', fontSize: 13 }}>{saveError}</span>}
           {form.published ? (
             <a
               href={`${baseUrl}/embed/${form.slug}`}
@@ -241,6 +269,8 @@ export default function FormEditor() {
               onChange={(changes) => updateStep(i, changes)}
               onChangeType={(type) => changeFieldType(i, type)}
               onMove={(dir) => moveStep(i, dir)}
+              onCombine={(dir) => combineSteps(i, dir)}
+              onSplit={() => splitGroup(i)}
               onRemove={() => removeStep(i)}
             />
           ))}
@@ -744,8 +774,15 @@ window.addEventListener('message', function(e) {
 /* ===========================
    StepEditor - Collapsible question card
    =========================== */
-function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange, onChangeType, onMove, onRemove }) {
-  const fieldDef = FIELD_TYPE_MAP[step.type];
+function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange, onChangeType, onMove, onCombine, onSplit, onRemove }) {
+  const isGroup = step.type === 'group';
+  const fieldDef = isGroup ? null : FIELD_TYPE_MAP[step.type];
+  // Combining is only offered between two adjacent single questions (max 2 per step).
+  const canCombineAbove = !isGroup && index > 0 && allSteps[index - 1]?.type !== 'group';
+  const canCombineBelow = !isGroup && index < total - 1 && allSteps[index + 1]?.type !== 'group';
+  const groupSummary = isGroup
+    ? (step.fields || []).map(f => f.label || f.question || f.type).join('  +  ')
+    : '';
 
   return (
     <div className="card" style={{ position: 'relative', marginBottom: 12 }}>
@@ -758,26 +795,38 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
           borderBottom: expanded ? '1px solid var(--border, #eee)' : 'none',
         }}
       >
-        <span style={{ fontSize: 20 }}>{fieldDef?.icon || '📝'}</span>
-        <div style={{ flex: 1 }}>
+        <span style={{ fontSize: 20 }}>{isGroup ? '🔗' : (fieldDef?.icon || '📝')}</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
           <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--primary)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-            {index + 1}. {fieldDef?.label || step.type}
+            {index + 1}. {isGroup ? 'Combined Step' : (fieldDef?.label || step.type)}
           </span>
-          <div style={{ fontSize: 14, color: '#636E72', marginTop: 2 }}>
-            {step.question || <em style={{ opacity: 0.5 }}>No question set</em>}
+          <div style={{ fontSize: 14, color: 'var(--text-light)', marginTop: 2 }}>
+            {isGroup ? groupSummary : (step.question || <em style={{ opacity: 0.5 }}>No question set</em>)}
           </div>
         </div>
-        <div style={{ display: 'flex', gap: 4 }} onClick={e => e.stopPropagation()}>
+        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', justifyContent: 'flex-end' }} onClick={e => e.stopPropagation()}>
           <button className="btn btn-sm btn-secondary" onClick={() => onMove(-1)} disabled={index === 0} title="Move up">&uarr;</button>
           <button className="btn btn-sm btn-secondary" onClick={() => onMove(1)} disabled={index === total - 1} title="Move down">&darr;</button>
+          {canCombineAbove && (
+            <button className="btn btn-sm btn-secondary" onClick={() => onCombine(-1)} title="Combine with the question above">&uarr; Combine</button>
+          )}
+          {canCombineBelow && (
+            <button className="btn btn-sm btn-secondary" onClick={() => onCombine(1)} title="Combine with the question below">&darr; Combine</button>
+          )}
+          {isGroup && (
+            <button className="btn btn-sm btn-secondary" onClick={onSplit} title="Split back into separate questions">Split</button>
+          )}
           <button className="btn btn-sm btn-danger" onClick={onRemove}>Remove</button>
         </div>
-        <span style={{ fontSize: 18, color: '#aaa', marginLeft: 4 }}>{expanded ? '▲' : '▼'}</span>
+        <span style={{ fontSize: 18, color: 'var(--text-light)', marginLeft: 4 }}>{expanded ? '▲' : '▼'}</span>
       </div>
 
       {/* Expanded content */}
       {expanded && (
         <div style={{ paddingTop: 16 }}>
+          {isGroup ? (
+            <GroupFieldsEditor step={step} allSteps={allSteps} onChange={onChange} />
+          ) : (<>
           {/* Field Type Selector - visual grid */}
           <div className="input-group">
             <label>Field Type</label>
@@ -791,11 +840,11 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
                   style={{
                     display: 'flex', alignItems: 'center', gap: 8,
                     padding: '10px 12px',
-                    border: step.type === ft.value ? '2px solid var(--primary, #6C5CE7)' : '2px solid #e0e0e0',
+                    border: step.type === ft.value ? '2px solid var(--primary)' : '2px solid var(--border)',
                     borderRadius: 10,
-                    background: step.type === ft.value ? 'rgba(108,92,231,0.08)' : '#fafafa',
+                    background: step.type === ft.value ? 'rgba(108,92,231,0.08)' : 'transparent',
                     cursor: 'pointer', fontSize: 13, fontWeight: step.type === ft.value ? 700 : 500,
-                    color: step.type === ft.value ? 'var(--primary, #6C5CE7)' : '#333',
+                    color: step.type === ft.value ? 'var(--primary)' : 'var(--text)',
                     transition: 'all 0.15s',
                   }}
                 >
@@ -973,9 +1022,129 @@ function StepEditor({ step, index, total, allSteps, expanded, onToggle, onChange
             currentStepId={step.id}
             onChange={condition => onChange({ condition })}
           />
+          </>)}
         </div>
       )}
     </div>
+  );
+}
+
+/* ===========================
+   GroupFieldsEditor - edits the two sub-fields of a combined step
+   =========================== */
+function GroupFieldsEditor({ step, allSteps, onChange }) {
+  const fields = step.fields || [];
+
+  function updateField(i, changes) {
+    onChange({ fields: fields.map((f, idx) => (idx === i ? { ...f, ...changes } : f)) });
+  }
+
+  function changeFieldType(i, newType) {
+    const def = FIELD_TYPE_MAP[newType];
+    const d = def?.defaults || {};
+    onChange({
+      fields: fields.map((f, idx) => (idx === i ? {
+        id: f.id,
+        type: newType,
+        question: d.question || '',
+        label: d.label || '',
+        placeholder: d.placeholder || '',
+        required: f.required || false,
+        ...(d.options ? { options: d.options } : {}),
+      } : f)),
+    });
+  }
+
+  return (
+    <>
+      <p style={{ fontSize: 13, color: 'var(--text-light)', marginBottom: 16 }}>
+        This step shows two questions on one screen. Use <strong>Split</strong> on the step header to separate them again.
+      </p>
+      {fields.map((f, i) => (
+        <div key={f.id} style={{ border: '1px solid var(--border)', borderRadius: 10, padding: 16, marginBottom: 12 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--primary)', textTransform: 'uppercase', letterSpacing: '0.5px', marginBottom: 12 }}>
+            Question {i + 1}
+          </div>
+          <SubFieldEditor
+            field={f}
+            onChange={changes => updateField(i, changes)}
+            onChangeType={type => changeFieldType(i, type)}
+          />
+        </div>
+      ))}
+      {/* The combined step is shown/hidden as a unit via a group-level condition. */}
+      <ConditionEditor
+        condition={step.condition}
+        allSteps={allSteps}
+        currentStepId={step.id}
+        onChange={condition => onChange({ condition })}
+      />
+    </>
+  );
+}
+
+/* ===========================
+   SubFieldEditor - compact editor for a single field inside a combined step
+   =========================== */
+function SubFieldEditor({ field, onChange, onChangeType }) {
+  return (
+    <>
+      <div className="input-group">
+        <label>Field Type</label>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: 8, marginTop: 4 }}>
+          {FIELD_TYPES.map(ft => (
+            <button
+              key={ft.value}
+              onClick={() => onChangeType(ft.value)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px',
+                border: field.type === ft.value ? '2px solid var(--primary)' : '2px solid var(--border)',
+                borderRadius: 10,
+                background: field.type === ft.value ? 'rgba(108,92,231,0.08)' : 'transparent',
+                cursor: 'pointer', fontSize: 13, fontWeight: field.type === ft.value ? 700 : 500,
+                color: field.type === ft.value ? 'var(--primary)' : 'var(--text)',
+                transition: 'all 0.15s',
+              }}
+            >
+              <span style={{ fontSize: 18 }}>{ft.icon}</span>
+              {ft.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginTop: 16 }}>
+        <div className="input-group">
+          <label>Question</label>
+          <input className="input" value={field.question || ''} onChange={e => onChange({ question: e.target.value })} placeholder="Your question..." />
+        </div>
+        <div className="input-group">
+          <label>Label / ID</label>
+          <input className="input" value={field.label || ''} onChange={e => onChange({ label: e.target.value })} placeholder="e.g. Name, Email..." />
+        </div>
+      </div>
+
+      {!['select', 'multi-select', 'yes-no', 'rating', 'image-select', 'address'].includes(field.type) && (
+        <div className="input-group" style={{ marginTop: 12 }}>
+          <label>Placeholder</label>
+          <input className="input" value={field.placeholder || ''} onChange={e => onChange({ placeholder: e.target.value })} placeholder="Placeholder text..." />
+        </div>
+      )}
+
+      {(field.type === 'select' || field.type === 'multi-select') && (
+        <div className="input-group" style={{ marginTop: 12 }}>
+          <label>Options</label>
+          <OptionsTextarea options={field.options || []} onChange={onChange} />
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 24, marginTop: 16 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14 }}>
+          <input type="checkbox" checked={field.required || false} onChange={e => onChange({ required: e.target.checked })} />
+          Required
+        </label>
+      </div>
+    </>
   );
 }
 
@@ -1358,31 +1527,41 @@ function ImageSelectEditor({ options, onChange }) {
    =========================== */
 function ConditionEditor({ condition, allSteps, currentStepId, onChange }) {
   const enabled = !!condition;
-  const previousSteps = allSteps.filter(s => s.id !== currentStepId);
+  // Build the list of referenceable fields, expanding combined steps into their
+  // individual sub-fields and excluding the current step (and its own sub-fields).
+  const fieldOptions = [];
+  for (const s of allSteps) {
+    if (s.id === currentStepId) continue;
+    if (s.type === 'group' && Array.isArray(s.fields)) {
+      for (const f of s.fields) fieldOptions.push({ id: f.id, label: f.label || f.id });
+    } else {
+      fieldOptions.push({ id: s.id, label: s.label || s.id });
+    }
+  }
 
   function toggle() {
     if (enabled) {
       onChange(null);
     } else {
-      onChange({ field: previousSteps[0]?.id || '', op: 'equals', value: '' });
+      onChange({ field: fieldOptions[0]?.id || '', op: 'equals', value: '' });
     }
   }
 
-  if (previousSteps.length === 0) return null;
+  if (fieldOptions.length === 0) return null;
 
   return (
-    <div style={{ marginTop: 16, padding: 14, background: '#fafafa', borderRadius: 10, border: '1px solid #eee' }}>
+    <div style={{ marginTop: 16, padding: 14, background: 'var(--bg)', borderRadius: 10, border: '1px solid var(--border)' }}>
       <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14, fontWeight: 600, cursor: 'pointer' }}>
         <input type="checkbox" checked={enabled} onChange={toggle} />
         Conditional Logic
       </label>
       {enabled && condition && (
         <div style={{ display: 'flex', gap: 8, marginTop: 10, alignItems: 'center', flexWrap: 'wrap' }}>
-          <span style={{ fontSize: 13, color: '#636E72' }}>Show this step only if</span>
+          <span style={{ fontSize: 13, color: 'var(--text-light)' }}>Show this step only if</span>
           <select className="input" value={condition.field || ''} onChange={e => onChange({ ...condition, field: e.target.value })} style={{ width: 'auto', minWidth: 140, padding: '6px 10px', fontSize: 13 }}>
             <option value="">-- Select field --</option>
-            {previousSteps.map(s => (
-              <option key={s.id} value={s.id}>{s.label || s.id}</option>
+            {fieldOptions.map(o => (
+              <option key={o.id} value={o.id}>{o.label}</option>
             ))}
           </select>
           <select className="input" value={condition.op || 'equals'} onChange={e => onChange({ ...condition, op: e.target.value })} style={{ width: 'auto', padding: '6px 10px', fontSize: 13 }}>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { api } from '../api';
+import { Alert, LogoMark } from '../components/AdminUI';
 
 export default function Login({ onLogin }) {
   const [email, setEmail] = useState('');
@@ -20,7 +21,7 @@ export default function Login({ onLogin }) {
   return (
     <div className="login-container">
       <div className="login-box card">
-        <h1>OpenFlow</h1>
+        <h1><LogoMark size={32} className="logo-mark" />OpenFlow</h1>
         <form onSubmit={handleSubmit}>
           <div className="input-group">
             <label>E-Mail</label>
@@ -30,7 +31,7 @@ export default function Login({ onLogin }) {
             <label>Password</label>
             <input className="input" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
           </div>
-          {error && <p style={{ color: '#E17055', marginBottom: 16, fontSize: 14 }}>{error}</p>}
+          <Alert type="error">{error}</Alert>
           <button type="submit" className="btn btn-primary" style={{ width: '100%', justifyContent: 'center' }}>
             Sign in
           </button>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { api } from '../api';
+import { PageHeader, Alert } from '../components/AdminUI';
 
 const DEFAULT_BRANDING = { logoVisible: true, logoUrl: '' };
 
@@ -31,13 +32,11 @@ export default function Settings() {
 
   return (
     <div>
-      <div style={{ marginBottom: 24 }}>
-        <h2>Settings</h2>
-      </div>
+      <PageHeader title="Settings" />
 
       <form onSubmit={handleSave}>
         <div className="card" style={{ marginBottom: 16 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 20 }}>
+          <div className="section-header">
             <span style={{ fontSize: 20 }}>🎨</span>
             <div>
               <h3 style={{ margin: 0 }}>Branding</h3>
@@ -57,7 +56,7 @@ export default function Settings() {
                 />
                 Show logo in sidebar
               </label>
-              <span style={{ fontSize: 11, color: '#999', marginTop: 8, display: 'block' }}>
+              <span style={{ fontSize: 11, color: 'var(--text-light)', marginTop: 8, display: 'block' }}>
                 Uncheck to hide the logo entirely from the sidebar footer.
               </span>
             </div>
@@ -72,25 +71,25 @@ export default function Settings() {
                 placeholder="https://example.com/logo.png"
                 disabled={!branding.logoVisible}
               />
-              <span style={{ fontSize: 11, color: '#999', marginTop: 4, display: 'block' }}>
+              <span style={{ fontSize: 11, color: 'var(--text-light)', marginTop: 4, display: 'block' }}>
                 Leave blank to use the built-in default logo. Best results: white PNG/SVG, max height 24px.
               </span>
             </div>
           </div>
 
           {branding.logoVisible && branding.logoUrl && (
-            <div style={{ marginTop: 16, padding: 16, background: '#2D3436', borderRadius: 10, display: 'inline-flex', alignItems: 'center', gap: 12 }}>
+            <div style={{ marginTop: 16, padding: 16, background: 'var(--sidebar-bg)', borderRadius: 10, display: 'inline-flex', alignItems: 'center', gap: 12 }}>
               <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>Preview:</span>
               <img src={branding.logoUrl} alt="Logo preview" style={{ height: 20, maxWidth: 140, objectFit: 'contain' }} />
             </div>
           )}
         </div>
 
-        {error && <p style={{ color: 'var(--danger)', marginBottom: 12, fontSize: 14 }}>{error}</p>}
+        <Alert type="error">{error}</Alert>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
           <button className="btn btn-primary" type="submit">Save Settings</button>
-          {saved && <span style={{ fontSize: 14, color: 'var(--success, #00b894)' }}>Saved!</span>}
+          {saved && <span style={{ fontSize: 14, color: 'var(--success)' }}>Saved!</span>}
         </div>
       </form>
     </div>

--- a/frontend/src/pages/Submissions.jsx
+++ b/frontend/src/pages/Submissions.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { api } from '../api';
+import { PageHeader, Alert, EmptyState, Loading } from '../components/AdminUI';
+import { flattenFields } from '../utils/steps';
 
 function formatValue(val, step) {
   if (step.type === 'address' && val && typeof val === 'object') {
@@ -37,35 +39,29 @@ export default function Submissions() {
       .catch(err => setError(err.message || 'Failed to load submissions'));
   }, [id, page]);
 
-  if (!form && !error) return <div>Loading...</div>;
+  if (!form && !error) return <Loading />;
 
-  const steps = form?.steps || [];
+  // Flatten combined "group" steps so each underlying field gets its own column.
+  const fields = flattenFields(form?.steps || []);
   const totalPages = Math.ceil(total / 20);
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
-        <div>
-          <Link to={`/forms/${id}`} style={{ color: '#636E72', textDecoration: 'none', fontSize: 13 }}>&larr; Back to form</Link>
-          <h2 style={{ marginTop: 8 }}>Responses: {form?.title}</h2>
-          <p style={{ color: '#636E72', fontSize: 14 }}>{total} entries</p>
-        </div>
+      <PageHeader
+        title={`Responses: ${form?.title || ''}`}
+        subtitle={`${total} entries`}
+        backTo={`/forms/${id}`}
+        backLabel="← Back to form"
+      >
         <a href={api.exportSubmissions(id)} className="btn btn-secondary" style={{ textDecoration: 'none' }}>
           Export CSV
         </a>
-      </div>
+      </PageHeader>
 
-      {error && (
-        <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
-          {error}
-        </div>
-      )}
+      <Alert type="error">{error}</Alert>
 
       {submissions.length === 0 ? (
-        <div className="card" style={{ textAlign: 'center', padding: 60 }}>
-          <h3>No responses yet</h3>
-          <p style={{ color: '#636E72' }}>Publish and share your form to start collecting responses.</p>
-        </div>
+        <EmptyState title="No responses yet" message="Publish and share your form to start collecting responses." />
       ) : (
         <>
           <div className="card" style={{ padding: 0, overflow: 'auto' }}>
@@ -73,20 +69,20 @@ export default function Submissions() {
               <thead>
                 <tr>
                   <th>#</th>
-                  {steps.map(s => <th key={s.id}>{s.label || s.question}</th>)}
+                  {fields.map(s => <th key={s.id}>{s.label || s.question}</th>)}
                   <th>Date</th>
                 </tr>
               </thead>
               <tbody>
                 {submissions.map((sub, i) => (
                   <tr key={sub.id}>
-                    <td style={{ color: '#636E72' }}>{(page - 1) * 20 + i + 1}</td>
-                    {steps.map(s => (
+                    <td style={{ color: 'var(--text-light)' }}>{(page - 1) * 20 + i + 1}</td>
+                    {fields.map(s => (
                       <td key={s.id}>
                         {formatValue(sub.data[s.id], s)}
                       </td>
                     ))}
-                    <td style={{ fontSize: 13, color: '#636E72', whiteSpace: 'nowrap' }}>
+                    <td style={{ fontSize: 13, color: 'var(--text-light)', whiteSpace: 'nowrap' }}>
                       {new Date(sub.created_at).toLocaleString('en')}
                     </td>
                   </tr>

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { api } from '../api';
+import { PageHeader, Alert } from '../components/AdminUI';
 
 export default function Users() {
   const [users, setUsers] = useState([]);
@@ -58,12 +59,11 @@ export default function Users() {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
-        <h2>Users</h2>
+      <PageHeader title="Users">
         <button className="btn btn-primary" onClick={() => setShowForm(!showForm)}>
           {showForm ? 'Cancel' : '+ Add User'}
         </button>
-      </div>
+      </PageHeader>
 
       {showForm && (
         <div className="card" style={{ marginBottom: 16 }}>
@@ -86,12 +86,13 @@ export default function Users() {
               </div>
               <button className="btn btn-primary" type="submit" style={{ height: 44 }}>Create</button>
             </div>
-            {error && <p style={{ color: 'var(--danger)', marginTop: 8, fontSize: 14 }}>{error}</p>}
+            <Alert type="error" style={{ marginTop: 8, marginBottom: 0 }}>{error}</Alert>
           </form>
         </div>
       )}
 
       <div className="card">
+        <div className="table-wrap">
         <table className="table">
           <thead>
             <tr>
@@ -110,7 +111,7 @@ export default function Users() {
                     {user.role || 'user'}
                   </span>
                 </td>
-                <td style={{ fontSize: 13, color: '#636E72' }}>{new Date(user.created_at).toLocaleDateString()}</td>
+                <td style={{ fontSize: 13, color: 'var(--text-light)' }}>{new Date(user.created_at).toLocaleDateString()}</td>
                 <td>
                   <div style={{ display: 'flex', gap: 4 }}>
                     <button className="btn btn-sm btn-secondary" onClick={() => toggleRole(user)} title="Toggle role">
@@ -125,6 +126,7 @@ export default function Users() {
             ))}
           </tbody>
         </table>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -14,8 +14,10 @@
   --border: #DFE6E9;
   --success: #00B894;
   --danger: #E17055;
+  --warning: #E67E22;
   --radius: 12px;
-  --shadow: 0 2px 12px rgba(0,0,0,0.08);
+  --radius-sm: 8px;
+  --shadow: 0 1px 2px rgba(45,52,54,0.04), 0 4px 16px rgba(45,52,54,0.06);
   --sidebar-bg: #2D3436;
   --input-bg: transparent;
 }
@@ -87,24 +89,23 @@ input, select, textarea {
   letter-spacing: -0.5px;
   margin-bottom: 32px;
   padding: 0 8px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-.admin-sidebar h1 .logo-icon {
-  display: inline-block;
-  width: 28px;
-  height: 28px;
-  background: linear-gradient(135deg, #6C5CE7, #a29bfe);
-  border-radius: 7px;
-  text-align: center;
-  line-height: 28px;
-  font-size: 16px;
-  margin-right: 10px;
-  vertical-align: middle;
+.logo-mark {
+  display: block;
+  flex-shrink: 0;
 }
 
 .login-box h1 {
   font-family: 'Space Grotesk', sans-serif;
   letter-spacing: -0.5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
 }
 
 .admin-sidebar nav a {
@@ -115,28 +116,140 @@ input, select, textarea {
   border-radius: 8px;
   margin-bottom: 4px;
   font-size: 14px;
+  border-left: 3px solid transparent;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
-.admin-sidebar nav a:hover,
-.admin-sidebar nav a.active {
-  background: rgba(255,255,255,0.1);
+.admin-sidebar nav a:hover {
+  background: rgba(255,255,255,0.08);
   color: white;
+}
+
+.admin-sidebar nav a.active {
+  background: rgba(108,92,231,0.22);
+  color: white;
+  border-left-color: var(--primary);
 }
 
 .admin-main {
   flex: 1;
   padding: 32px;
+  width: 100%;
   max-width: 1200px;
+  margin-inline: auto;
   min-height: 100vh;
 }
 
 /* Cards */
 .card {
   background: var(--card);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   padding: 24px;
   margin-bottom: 16px;
+}
+
+/* Page header — shared across all admin pages */
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.page-header-titles h2 {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+}
+
+.page-subtitle {
+  color: var(--text-light);
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+.page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.back-link {
+  display: inline-block;
+  color: var(--text-light);
+  text-decoration: none;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.back-link:hover {
+  color: var(--primary);
+}
+
+/* Section header inside cards (icon + title + optional hint) */
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.section-header h3 {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0;
+}
+
+/* Alerts / banners */
+.alert {
+  padding: 10px 16px;
+  margin-bottom: 16px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  border: 1px solid transparent;
+}
+
+.alert-error {
+  background: rgba(225,112,85,0.12);
+  color: var(--danger);
+  border-color: rgba(225,112,85,0.25);
+}
+
+.alert-success {
+  background: rgba(0,184,148,0.12);
+  color: var(--success);
+  border-color: rgba(0,184,148,0.25);
+}
+
+/* Loading & empty states */
+.loading-state {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-light);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 24px;
+}
+
+.empty-state h3 {
+  margin-bottom: 8px;
+}
+
+.empty-state p {
+  color: var(--text-light);
+  margin-bottom: 24px;
+}
+
+/* Table wrapper — lets wide tables scroll on small screens */
+.table-wrap {
+  overflow-x: auto;
 }
 
 /* Buttons */
@@ -272,7 +385,7 @@ input, select, textarea {
 
 .badge-draft {
   background: #FDF2E9;
-  color: #E67E22;
+  color: var(--warning);
 }
 
 /* Login */

--- a/frontend/src/utils/steps.js
+++ b/frontend/src/utils/steps.js
@@ -1,0 +1,14 @@
+// Expand combined "group" steps into their individual leaf fields.
+// A group step has the shape { id, type: 'group', fields: [fieldA, fieldB] };
+// every other step is itself a leaf field. Mirrors backend/src/utils/steps.js.
+export function flattenFields(steps) {
+  const out = [];
+  for (const step of steps || []) {
+    if (step && step.type === 'group' && Array.isArray(step.fields)) {
+      for (const field of step.fields) out.push(field);
+    } else if (step) {
+      out.push(step);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Implements four requested changes and bumps the version to **0.12.0**.

### 1. Clone a form
- New `POST /api/forms/:id/clone` endpoint and a **Duplicate** action on the Forms dashboard.
- Copies the form's structure (questions, theme, end screen) **and** integrations.
- The copy is created as a **draft** with a fresh URL slug and a `" (Copy)"` title.
- Submissions and analytics are **never** copied; copied integrations are created **disabled** so a clone can't send leads to live destinations until reviewed and re-enabled.

### 2. Combine up to two questions into one step (reversible)
- New backward-compatible `type: 'group'` step holding a `fields: [a, b]` array (no DB migration).
- Editor: **Combine ↑ / Combine ↓** buttons on each question, and **Split** to separate a combined step again.
- Renderer: both fields appear on one screen and are validated before advancing.
- Each field keeps its own id, so it still gets its own column in the submissions table, CSV export, email/Sheets integrations, and conditional-logic targets. Shared `flattenFields()` helper on both front and back end.

### 3. Cooler logo icon
- Custom inline-SVG "flow" mark replaces the old diamond glyph in the sidebar and on the login screen.
- Added a matching **favicon** (was previously missing).

### 4. Admin UI rework (cleanup + light visual refresh)
- Shared `PageHeader` / `Alert` / `Loading` / `EmptyState` primitives replace duplicated, drifted inline blocks across every admin page.
- Content is centred on wide screens, the active sidebar item is clearer, card/shadow refreshed, hardcoded colours swapped for theme tokens (better dark mode), tables scroll on small screens, and the form-title field no longer overflows on mobile.

## Testing
- `cd backend && npm test` — new tests for clone behaviour and combined-step submission validation pass (6/6 new).
- `cd frontend && npm run build` — production build succeeds.
- ⚠️ Note: 5 **pre-existing** test failures remain in `auth.test.js` (user deletion) and `validation.test.js` (analytics `track`) — they fail on the base branch too and are untouched by this PR.

## Verify locally
1. Run backend + frontend dev servers, log in.
2. Click through every admin page — consistent headers/alerts/empty+loading states, centred content, new logo + favicon, dark/light toggle, narrow viewport.
3. Duplicate a form with an integration → `"… (Copy)"` draft, new URL, integration present but **disabled**, 0 responses.
4. Combine two fields (e.g. Email + Phone), preview, submit → both validated and shown as separate columns; Split restores two steps. Confirm an existing (ungrouped) form is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVTtqyPSz3TafeDquh9tSE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVTtqyPSz3TafeDquh9tSE)_