### PR TITLE
Document the lodgely lead-intake integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.13.1] - 2026-06-24
+
+### Docs
+- **Documented the lodgely integration** — A new "lodgely (lead intake hub)" subsection in the README and a note in `CLAUDE.md` explain that [lodgely](https://github.com/vidual-labs/lodgely) can *pull* a form's submissions into a specific client by signing in to the admin API and reading `GET /api/submissions/:formId`. Configured entirely on the lodgely side; nothing to set up in OpenFlow beyond an admin account. No code changes.
+
 ## [0.13.0] - 2026-06-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets), analytics, and a WordPress plugin.
 
-**Current Version**: 0.7.4 (see version badge in README.md and CHANGELOG.md)
+**Current Version**: 0.13.1 (see version badge in README.md and CHANGELOG.md)
 
 ## Architecture
 
@@ -144,6 +144,25 @@ Key tables:
 - **Admin** (`/api/forms`, `/api/submissions`, `/api/auth`): JWT auth required.
 - **Integrations** (`/api/integrations`): Test, create, update, delete integrations.
 - **Analytics** (`/api/analytics`): Get funnel and trend data.
+
+### External consumer: lodgely (lead intake hub)
+
+[lodgely](https://github.com/vidual-labs/lodgely) has a built-in OpenFlow
+connector that **pulls** submissions out of an install — it is not a push
+integration configured here, but it does depend on this API's shape:
+
+- It logs in via `POST /api/auth/login` (email + password) and reads the JWT
+  from the **`token` httpOnly cookie** in the response, then sends it as a
+  `Bearer` token. There is no API-token mechanism, so this login flow is the
+  only auth path — **don't remove the Set-Cookie token or stop accepting the
+  Bearer header without coordinating**.
+- It reads `GET /api/forms` (to list forms), `GET /api/forms/:id` (to read
+  `steps` for field mapping) and `GET /api/submissions/:formId` (paged, newest
+  first) where each submission's `data` is keyed by field id. Changing those
+  response shapes is a breaking change for the connector.
+
+A long-lived API token would be a cleaner contract than storing a password in
+lodgely — a reasonable future enhancement if this integration grows.
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.13.0
+# 🌊 OpenFlow v0.13.1
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents
@@ -207,6 +207,21 @@ Auto-append each submission using a Google Service Account.
 - Configurable sheet name
 
 > 💡 Each integration has an **Enable/Disable** toggle and a **Test** button to verify your setup with sample data.
+
+### 🏨 lodgely (lead intake hub)
+
+[lodgely](https://github.com/vidual-labs/lodgely) — a self-hosted lead intake
+hub — can **pull** a form's submissions into a specific client view. Unlike the
+push integrations above, this is configured entirely in lodgely (under
+**Imports → OpenFlow**), so there is nothing to set up on the OpenFlow side
+beyond an admin account:
+
+- lodgely signs in with an OpenFlow login (email + password) to mint a session
+  token, then reads submissions from the admin API on a schedule.
+- It maps each OpenFlow field to a lead field; unmapped answers are kept as
+  custom answers. Re-fetches are idempotent on the submission id.
+- Point lodgely at your OpenFlow base URL and pick the form — leads flow into
+  the chosen client automatically.
 
 ---
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Docs-only. Documents that [lodgely](https://github.com/vidual-labs/lodgely) (a self-hosted lead intake hub) can **pull** a form's submissions into a specific client by signing in to the admin API and reading `GET /api/submissions/:formId`. The connector lives entirely in lodgely — nothing to configure in OpenFlow beyond an admin account.

- **README** — new "lodgely (lead intake hub)" subsection under Integrations (a pull consumer, contrasted with the existing push integrations).
- **CLAUDE.md** — a maintainer note that an external consumer depends on the login-cookie auth (`POST /api/auth/login` → `token` cookie → Bearer) and the `GET /api/forms`, `/api/forms/:id`, `/api/submissions/:formId` response shapes, so those shouldn't be broken casually; also refreshed the stale `Current Version` line.
- Patch bump **0.13.0 → 0.13.1** (README badge, CHANGELOG, backend + frontend `package.json`).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017c48QGNee6DCUvnsxzoxNF

---
_Generated by [Claude Code](https://claude.ai/code/session_017c48QGNee6DCUvnsxzoxNF)_