### PR TITLE
Add read-only API tokens for programmatic access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.14.0] - 2026-06-24
+
+### Added
+- **Read-only API tokens** — Mint long-lived API tokens under **Settings → API Tokens** for programmatic API access (e.g. the [lodgely](https://github.com/vidual-labs/lodgely) connector) without sharing your password. Tokens are `ofw_`-prefixed, stored only as a SHA-256 hash (shown in plaintext once at creation), and are **read-only**: the auth middleware authenticates the owning user but rejects any non-GET request made with a token. Tokens can be listed and revoked individually; a token can never be used to manage tokens. New endpoints: `GET/POST /api/auth/tokens`, `DELETE /api/auth/tokens/:id`.
+
 ## [0.13.1] - 2026-06-24
 
 ### Docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets), analytics, and a WordPress plugin.
 
-**Current Version**: 0.13.1 (see version badge in README.md and CHANGELOG.md)
+**Current Version**: 0.14.0 (see version badge in README.md and CHANGELOG.md)
 
 ## Architecture
 
@@ -151,18 +151,28 @@ Key tables:
 connector that **pulls** submissions out of an install — it is not a push
 integration configured here, but it does depend on this API's shape:
 
-- It logs in via `POST /api/auth/login` (email + password) and reads the JWT
-  from the **`token` httpOnly cookie** in the response, then sends it as a
-  `Bearer` token. There is no API-token mechanism, so this login flow is the
-  only auth path — **don't remove the Set-Cookie token or stop accepting the
-  Bearer header without coordinating**.
+- **Auth (preferred): an API token.** A logged-in user mints a read-only token
+  under **Settings → API Tokens** (`POST /api/auth/tokens`), and lodgely sends
+  it as a `Bearer` token. See "API tokens" below.
+- **Auth (fallback): login.** lodgely can still log in via `POST /api/auth/login`
+  (email + password) and read the JWT from the **`token` httpOnly cookie**, then
+  send it as a `Bearer` token. **Don't remove the Set-Cookie token or stop
+  accepting the Bearer header without coordinating.**
 - It reads `GET /api/forms` (to list forms), `GET /api/forms/:id` (to read
   `steps` for field mapping) and `GET /api/submissions/:formId` (paged, newest
   first) where each submission's `data` is keyed by field id. Changing those
   response shapes is a breaking change for the connector.
 
-A long-lived API token would be a cleaner contract than storing a password in
-lodgely — a reasonable future enhancement if this integration grows.
+### API tokens
+
+`backend/src/models/apiTokens.js` + the `/api/auth/tokens` routes implement
+long-lived, **read-only** API tokens (format `ofw_<40 hex>`). Only a SHA-256
+hash is stored; the plaintext is shown once at creation. The auth middleware
+(`middleware/auth.js`) recognises a token by its `ofw_` prefix, authenticates
+the owning user, and **rejects any non-GET/HEAD request** (`req.authVia ===
+'api_token'`). `requireSession` blocks token-authed callers from the
+token-management endpoints, so a token can never mint or list tokens. Tokens are
+managed in the UI under **Settings → API Tokens**.
 
 ## Common Tasks
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.13.1
+# 🌊 OpenFlow v0.14.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents
@@ -72,6 +72,7 @@
 - **SQLite** — Zero-config database, no external DB needed
 - **🛡️ Rate Limiting** — Built-in in-memory spam protection
 - **👥 Multi-User** — Admin can invite users, assign roles (admin/user)
+- **🔑 API Tokens** — Read-only tokens for programmatic API access (e.g. the lodgely connector); created under Settings, hashed at rest, revocable anytime
 - **💾 Backup & Restore** — Admins can download a full JSON snapshot of the database and restore it later; older backups are auto-migrated to the current format on restore
 - **🌙 Dark Mode** — Auto/light/dark theme toggle for the admin interface
 - **🛡️ Delete Protection** — Published forms require typing the form name to confirm deletion
@@ -216,8 +217,11 @@ push integrations above, this is configured entirely in lodgely (under
 **Imports → OpenFlow**), so there is nothing to set up on the OpenFlow side
 beyond an admin account:
 
-- lodgely signs in with an OpenFlow login (email + password) to mint a session
-  token, then reads submissions from the admin API on a schedule.
+- **Recommended:** create a **read-only API token** under **Settings → API
+  Tokens** and paste it into lodgely. The token can only read forms and
+  submissions, never modify anything, and you can revoke it anytime without
+  touching your password.
+- Alternatively, lodgely can sign in with an OpenFlow login (email + password).
 - It maps each OpenFlow field to a lead field; unmapped answers are kept as
   custom answers. Re-fetches are idempotent on the submission id.
 - Point lodgely at your OpenFlow base URL and pick the form — leads flow into

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const { looksLikeApiToken, findByToken, touchLastUsed } = require('../models/apiTokens');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'change-me-in-production';
 if (!process.env.JWT_SECRET) {
@@ -10,9 +11,28 @@ function authMiddleware(req, res, next) {
   if (!token) {
     return res.status(401).json({ error: 'Not authenticated' });
   }
+
+  // Long-lived API tokens (e.g. the lodgely connector). These are read-only:
+  // they authenticate the owning user but may only perform safe (GET/HEAD)
+  // requests — anything that mutates state is rejected.
+  if (looksLikeApiToken(token)) {
+    const row = findByToken(token);
+    if (!row) {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return res.status(403).json({ error: 'API tokens are read-only' });
+    }
+    req.userId = row.user_id;
+    req.authVia = 'api_token';
+    touchLastUsed(row.id);
+    return next();
+  }
+
   try {
     const payload = jwt.verify(token, JWT_SECRET);
     req.userId = payload.userId;
+    req.authVia = 'session';
     next();
   } catch {
     return res.status(401).json({ error: 'Invalid token' });
@@ -34,4 +54,14 @@ function requireAdmin(req, res, next) {
   next();
 }
 
-module.exports = { authMiddleware, signToken, requireAdmin };
+// Must run after authMiddleware. Rejects requests authenticated by an API
+// token, so that token-management endpoints (and anything else that should
+// require a real login) can never be driven by a token itself.
+function requireSession(req, res, next) {
+  if (req.authVia === 'api_token') {
+    return res.status(403).json({ error: 'This action requires a logged-in session, not an API token' });
+  }
+  next();
+}
+
+module.exports = { authMiddleware, signToken, requireAdmin, requireSession };

--- a/backend/src/models/apiTokens.js
+++ b/backend/src/models/apiTokens.js
@@ -1,0 +1,89 @@
+const crypto = require('crypto');
+const { v4: uuid } = require('uuid');
+const { getDb } = require('./db');
+
+// ──────────────────────────────────────────
+// API tokens
+//
+// Long-lived, read-only API tokens for programmatic API access (e.g. the
+// lodgely lead-intake connector pulling submissions). Unlike the JWT login
+// flow, a token can be revoked individually without changing the account
+// password, and it is read-only — the auth middleware rejects any non-GET
+// request authenticated by a token.
+//
+// The plaintext token is shown to the user exactly once, at creation. Only a
+// SHA-256 hash is stored, so a database leak does not expose usable tokens.
+// ──────────────────────────────────────────
+
+const TOKEN_PREFIX = 'ofw_';
+
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+/** Generate a fresh opaque token string: `ofw_` + 40 hex chars. */
+function generateToken() {
+  return TOKEN_PREFIX + crypto.randomBytes(20).toString('hex');
+}
+
+/** True if a string looks like one of our API tokens (cheap pre-check). */
+function looksLikeApiToken(value) {
+  return typeof value === 'string' && value.startsWith(TOKEN_PREFIX);
+}
+
+/**
+ * Create a token for a user. Returns the row metadata plus the one-time
+ * plaintext `token` — persist nothing but the hash.
+ */
+function createToken(userId, name) {
+  const db = getDb();
+  const token = generateToken();
+  const id = uuid();
+  // A recognisable, non-secret prefix so the UI can label which token is which.
+  const prefix = token.slice(0, TOKEN_PREFIX.length + 8);
+
+  db.prepare(
+    'INSERT INTO api_tokens (id, user_id, name, token_hash, token_prefix) VALUES (?, ?, ?, ?, ?)'
+  ).run(id, userId, name, hashToken(token), prefix);
+
+  const row = db.prepare(
+    'SELECT id, name, token_prefix, last_used_at, created_at FROM api_tokens WHERE id = ?'
+  ).get(id);
+
+  return { ...row, token };
+}
+
+/** List a user's tokens (metadata only — never the hash or plaintext). */
+function listTokens(userId) {
+  return getDb().prepare(
+    'SELECT id, name, token_prefix, last_used_at, created_at FROM api_tokens WHERE user_id = ? ORDER BY created_at DESC'
+  ).all(userId);
+}
+
+/** Resolve a plaintext token to its row, or undefined if unknown. */
+function findByToken(token) {
+  return getDb().prepare(
+    'SELECT id, user_id, name FROM api_tokens WHERE token_hash = ?'
+  ).get(hashToken(token));
+}
+
+/** Stamp last_used_at so operators can spot stale or rogue tokens. */
+function touchLastUsed(id) {
+  getDb().prepare("UPDATE api_tokens SET last_used_at = datetime('now') WHERE id = ?").run(id);
+}
+
+/** Revoke one of a user's tokens. Returns true if a row was deleted. */
+function revokeToken(userId, id) {
+  const result = getDb().prepare('DELETE FROM api_tokens WHERE id = ? AND user_id = ?').run(id, userId);
+  return result.changes > 0;
+}
+
+module.exports = {
+  TOKEN_PREFIX,
+  looksLikeApiToken,
+  createToken,
+  listTokens,
+  findByToken,
+  touchLastUsed,
+  revokeToken,
+};

--- a/backend/src/models/db.js
+++ b/backend/src/models/db.js
@@ -95,6 +95,19 @@ function initDb() {
     );
 
     CREATE INDEX IF NOT EXISTS idx_slug_history_form ON slug_history(form_id);
+
+    CREATE TABLE IF NOT EXISTS api_tokens (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      token_hash TEXT UNIQUE NOT NULL,
+      token_prefix TEXT NOT NULL,
+      last_used_at TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
   `);
 
   // Migrate: add role column if missing (existing DBs)

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,7 +1,8 @@
 const { Router } = require('express');
 const bcrypt = require('bcryptjs');
 const { getDb } = require('../models/db');
-const { authMiddleware, signToken } = require('../middleware/auth');
+const { authMiddleware, signToken, requireSession } = require('../middleware/auth');
+const apiTokens = require('../models/apiTokens');
 
 const router = Router();
 
@@ -116,6 +117,37 @@ router.delete('/users/:id', authMiddleware, requireAdmin, (req, res) => {
     console.error('Delete user error:', err);
     res.status(500).json({ error: 'Failed to delete user' });
   }
+});
+
+// --- API tokens (read-only, for programmatic API access e.g. lodgely) ---
+//
+// Any logged-in user manages their own tokens. requireSession ensures a token
+// can never be used to mint or enumerate tokens — only a real login can.
+
+// List the current user's tokens (metadata only — the secret is never returned).
+router.get('/tokens', authMiddleware, requireSession, (req, res) => {
+  res.json({ tokens: apiTokens.listTokens(req.userId) });
+});
+
+// Create a token. The plaintext is returned exactly once, here.
+router.post('/tokens', authMiddleware, requireSession, (req, res) => {
+  const name = typeof req.body.name === 'string' ? req.body.name.trim() : '';
+  if (!name) {
+    return res.status(400).json({ error: 'Token name is required' });
+  }
+  if (name.length > 100) {
+    return res.status(400).json({ error: 'Token name is too long (max 100 chars)' });
+  }
+
+  const created = apiTokens.createToken(req.userId, name);
+  res.status(201).json({ token: created });
+});
+
+// Revoke a token.
+router.delete('/tokens/:id', authMiddleware, requireSession, (req, res) => {
+  const ok = apiTokens.revokeToken(req.userId, req.params.id);
+  if (!ok) return res.status(404).json({ error: 'Token not found' });
+  res.json({ ok: true });
 });
 
 module.exports = router;

--- a/backend/tests/apiTokens.test.js
+++ b/backend/tests/apiTokens.test.js
@@ -1,0 +1,114 @@
+const request = require('supertest');
+const { createTestApp } = require('./setup');
+const bcrypt = require('bcryptjs');
+const { v4: uuid } = require('uuid');
+
+describe('API tokens', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  // Create a user and return a logged-in session cookie.
+  async function loginUser(email = 'owner@test.com', password = 'ownerpass', role = 'admin') {
+    const { getDb } = require('../src/models/db');
+    getDb().prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?, ?, ?, ?)')
+      .run(uuid(), email, bcrypt.hashSync(password, 10), role);
+    const res = await request(app).post('/api/auth/login').send({ email, password });
+    return res.headers['set-cookie'];
+  }
+
+  async function createToken(cookie, name = 'lodgely') {
+    const res = await request(app).post('/api/auth/tokens').set('Cookie', cookie).send({ name });
+    return res;
+  }
+
+  it('creates a token and returns the plaintext exactly once', async () => {
+    const cookie = await loginUser();
+    const res = await createToken(cookie, 'lodgely connector');
+
+    expect(res.status).toBe(201);
+    expect(res.body.token.token).toMatch(/^ofw_[0-9a-f]{40}$/);
+    expect(res.body.token.name).toBe('lodgely connector');
+    expect(res.body.token.token_prefix).toBe(res.body.token.token.slice(0, 12));
+  });
+
+  it('requires a name', async () => {
+    const cookie = await loginUser();
+    const res = await request(app).post('/api/auth/tokens').set('Cookie', cookie).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('lists tokens without exposing the secret', async () => {
+    const cookie = await loginUser();
+    await createToken(cookie, 'one');
+
+    const res = await request(app).get('/api/auth/tokens').set('Cookie', cookie);
+    expect(res.status).toBe(200);
+    expect(res.body.tokens).toHaveLength(1);
+    expect(res.body.tokens[0].name).toBe('one');
+    expect(res.body.tokens[0].token).toBeUndefined();
+    expect(res.body.tokens[0].token_hash).toBeUndefined();
+  });
+
+  it('authenticates a GET request with the token (read access)', async () => {
+    const cookie = await loginUser();
+    const { token } = (await createToken(cookie)).body.token;
+
+    const res = await request(app).get('/api/forms').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.forms)).toBe(true);
+  });
+
+  it('rejects a write request made with a token (read-only)', async () => {
+    const cookie = await loginUser();
+    const { token } = (await createToken(cookie)).body.token;
+
+    const res = await request(app)
+      .post('/api/forms')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Nope' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/read-only/i);
+  });
+
+  it('cannot use a token to manage tokens (requires a session)', async () => {
+    const cookie = await loginUser();
+    const { token } = (await createToken(cookie)).body.token;
+
+    const res = await request(app).get('/api/auth/tokens').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects an unknown token', async () => {
+    const res = await request(app)
+      .get('/api/forms')
+      .set('Authorization', 'Bearer ofw_deadbeefdeadbeefdeadbeefdeadbeefdeadbeef');
+    expect(res.status).toBe(401);
+  });
+
+  it('stops working once revoked', async () => {
+    const cookie = await loginUser();
+    const created = (await createToken(cookie)).body.token;
+
+    const del = await request(app).delete(`/api/auth/tokens/${created.id}`).set('Cookie', cookie);
+    expect(del.status).toBe(200);
+
+    const res = await request(app).get('/api/forms').set('Authorization', `Bearer ${created.token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('only scopes a token to its owner\'s forms', async () => {
+    const ownerCookie = await loginUser('owner2@test.com', 'pass', 'admin');
+    const { token } = (await createToken(ownerCookie)).body.token;
+
+    // Owner creates a form.
+    await request(app).post('/api/forms').set('Cookie', ownerCookie).send({ title: 'Mine' });
+
+    const res = await request(app).get('/api/forms').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.forms).toHaveLength(1);
+    expect(res.body.forms[0].title).toBe('Mine');
+  });
+});

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -32,6 +32,7 @@ beforeEach(() => {
   db.exec('DELETE FROM analytics_events');
   db.exec('DELETE FROM submissions');
   db.exec('DELETE FROM integrations');
+  db.exec('DELETE FROM api_tokens');
   db.exec('DELETE FROM forms');
   db.exec('DELETE FROM users');
   db.pragma('foreign_keys = ON');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -46,6 +46,11 @@ export const api = {
   deleteIntegration: (formId, id) => request(`/integrations/${formId}/${id}`, { method: 'DELETE' }),
   testIntegration: (formId, id) => request(`/integrations/${formId}/${id}/test`, { method: 'POST' }),
 
+  // API tokens (read-only programmatic access, e.g. the lodgely connector)
+  getApiTokens: () => request('/auth/tokens'),
+  createApiToken: (name) => request('/auth/tokens', { method: 'POST', body: JSON.stringify({ name }) }),
+  deleteApiToken: (id) => request(`/auth/tokens/${id}`, { method: 'DELETE' }),
+
   // User management (admin)
   getUsers: () => request('/auth/users'),
   createUser: (data) => request('/auth/users', { method: 'POST', body: JSON.stringify(data) }),

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -92,6 +92,139 @@ export default function Settings() {
           {saved && <span style={{ fontSize: 14, color: 'var(--success)' }}>Saved!</span>}
         </div>
       </form>
+
+      <ApiTokensCard />
+    </div>
+  );
+}
+
+function ApiTokensCard() {
+  const [tokens, setTokens] = useState([]);
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState('');
+  // The plaintext of a token we just created — shown exactly once.
+  const [revealed, setRevealed] = useState(null);
+  const [copied, setCopied] = useState(false);
+
+  function load() {
+    api.getApiTokens()
+      .then(d => setTokens(d.tokens || []))
+      .catch(() => {});
+  }
+
+  useEffect(() => { load(); }, []);
+
+  async function handleCreate(e) {
+    e.preventDefault();
+    setError('');
+    if (!name.trim()) { setError('Give the token a name.'); return; }
+    setCreating(true);
+    try {
+      const d = await api.createApiToken(name.trim());
+      setRevealed(d.token.token);
+      setCopied(false);
+      setName('');
+      load();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(id) {
+    if (!window.confirm('Revoke this token? Anything using it (e.g. a lodgely source) will stop working immediately.')) return;
+    setError('');
+    try {
+      await api.deleteApiToken(id);
+      load();
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  function copyToken() {
+    navigator.clipboard?.writeText(revealed).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {});
+  }
+
+  return (
+    <div className="card" style={{ marginTop: 24 }}>
+      <div className="section-header">
+        <span style={{ fontSize: 20 }}>🔑</span>
+        <div>
+          <h3 style={{ margin: 0 }}>API Tokens</h3>
+          <p style={{ color: 'var(--text-light)', fontSize: 13, margin: 0 }}>
+            Read-only tokens for programmatic API access — e.g. the lodgely lead-intake connector.
+            A token can read your forms and submissions but cannot change anything, and can be revoked
+            here at any time without affecting your password.
+          </p>
+        </div>
+      </div>
+
+      {revealed && (
+        <div style={{ marginBottom: 16, padding: 14, background: 'var(--sidebar-bg)', borderRadius: 10 }}>
+          <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.6)', marginBottom: 8 }}>
+            ⚠️ Copy this token now — it will not be shown again.
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <code style={{ flex: 1, color: '#fff', fontSize: 13, wordBreak: 'break-all', fontFamily: 'monospace' }}>{revealed}</code>
+            <button type="button" className="btn btn-primary" onClick={copyToken}>{copied ? 'Copied!' : 'Copy'}</button>
+            <button type="button" className="btn" onClick={() => setRevealed(null)}>Done</button>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleCreate} style={{ display: 'flex', gap: 10, alignItems: 'flex-end', marginBottom: 16 }}>
+        <div className="input-group" style={{ flex: 1, margin: 0 }}>
+          <label>Token name</label>
+          <input
+            className="input"
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="e.g. lodgely — Acme client"
+            maxLength={100}
+          />
+        </div>
+        <button className="btn btn-primary" type="submit" disabled={creating}>
+          {creating ? 'Generating…' : 'Generate token'}
+        </button>
+      </form>
+
+      <Alert type="error">{error}</Alert>
+
+      {tokens.length === 0 ? (
+        <p style={{ color: 'var(--text-light)', fontSize: 13 }}>No API tokens yet.</p>
+      ) : (
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+          <thead>
+            <tr style={{ textAlign: 'left', color: 'var(--text-light)', fontSize: 12 }}>
+              <th style={{ padding: '6px 8px' }}>Name</th>
+              <th style={{ padding: '6px 8px' }}>Token</th>
+              <th style={{ padding: '6px 8px' }}>Last used</th>
+              <th style={{ padding: '6px 8px' }}>Created</th>
+              <th style={{ padding: '6px 8px' }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {tokens.map(t => (
+              <tr key={t.id} style={{ borderTop: '1px solid var(--border)' }}>
+                <td style={{ padding: '8px' }}>{t.name}</td>
+                <td style={{ padding: '8px', fontFamily: 'monospace', color: 'var(--text-light)' }}>{t.token_prefix}…</td>
+                <td style={{ padding: '8px', color: 'var(--text-light)' }}>{t.last_used_at ? new Date(t.last_used_at + 'Z').toLocaleString() : '—'}</td>
+                <td style={{ padding: '8px', color: 'var(--text-light)' }}>{t.created_at ? new Date(t.created_at + 'Z').toLocaleDateString() : '—'}</td>
+                <td style={{ padding: '8px', textAlign: 'right' }}>
+                  <button type="button" className="btn btn-danger" onClick={() => handleRevoke(t.id)}>Revoke</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What & why

OpenFlow had **no API-token mechanism** — the only auth was an email/password login returning a 7-day JWT cookie. External consumers like the [lodgely](https://github.com/vidual-labs/lodgely) lead-intake connector therefore had to store a password. This adds **long-lived, read-only API tokens** so they can authenticate without one.

## How it works

- **Storage:** new `api_tokens` table + `backend/src/models/apiTokens.js`. Tokens are `ofw_<40 hex>`; only a **SHA-256 hash** is stored, and the plaintext is shown **once** at creation.
- **Read-only enforcement:** the auth middleware recognises a token by its `ofw_` prefix, authenticates the owning user (`req.authVia = 'api_token'`), and **rejects any non-GET/HEAD request** with 403. lodgely only does GETs, so this is sufficient — and it directly fixes the "over-privileged credential" downside.
- **Self-protection:** a new `requireSession` guard blocks token-authed callers from the token-management endpoints, so a token can never mint or enumerate tokens — only a real login can.
- **Endpoints:** `GET /api/auth/tokens`, `POST /api/auth/tokens` (`{ name }` → one-time plaintext), `DELETE /api/auth/tokens/:id`.
- **UI:** a **Settings → API Tokens** card — generate (one-time reveal + copy), list (name, masked prefix, last used, created), revoke.

## Tests

9 new backend tests (`backend/tests/apiTokens.test.js`): create + one-time reveal, name required, list hides the secret, token authenticates a GET, token rejected on write (403), token can't manage tokens, unknown token 401, revoke stops it working, owner scoping.

> Note: 5 pre-existing failures in `auth.test.js` / `validation.test.js` (user-delete role expectations + an analytics-validation endpoint) exist on `main` independent of this change — verified by running the suite on a clean checkout. This PR adds no new failures.

## Docs / version

CLAUDE.md (consumer note + new "API tokens" section), README (feature + updated lodgely-integration section), CHANGELOG; minor bump **0.13.1 → 0.14.0** (backend + frontend `package.json`).

## Follow-up

A companion lodgely PR will let an OpenFlow source authenticate with one of these tokens (keeping email/password as a fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017c48QGNee6DCUvnsxzoxNF

---
_Generated by [Claude Code](https://claude.ai/code/session_017c48QGNee6DCUvnsxzoxNF)_