### PR TITLE
Add optional lodgely link to lead notification emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.15.0] - 2026-07-02
+
+### Added
+- **Optional lodgely link in lead emails** — The Email Notification integration has a new "Include a link to lodgely in this email" toggle plus a lodgely URL field, both off/empty by default. When enabled, each lead notification email includes a button linking to the admin's lodgely instance, so clients who prefer email can still jump straight into lodgely. Per-integration setting, configured in **Integrations → Email Notification** on each form.
+
 ## [0.14.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.14.0
+# 🌊 OpenFlow v0.15.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.13.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.13.1",
+      "version": "0.15.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -73,8 +73,19 @@ async function runWebhook(config, formId, formTitle, data) {
 // Email notification
 // ──────────────────────────────────────────
 
+function escapeHtmlAttr(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 async function runEmail(config, formId, formTitle, data, steps) {
-  const { smtp_host, smtp_port = 587, smtp_user, smtp_pass, smtp_secure = false, to, from, subject } = config;
+  const {
+    smtp_host, smtp_port = 587, smtp_user, smtp_pass, smtp_secure = false, to, from, subject,
+    lodgely_link_enabled, lodgely_url,
+  } = config;
 
   if (!smtp_host || !to) throw new Error('SMTP host and recipient are required');
 
@@ -94,12 +105,17 @@ async function runEmail(config, formId, formTitle, data, steps) {
     return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:#555;">${field.label || field.question || field.id}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;">${val}</td></tr>`;
   }).join('');
 
+  const lodgelyLink = lodgely_link_enabled && lodgely_url
+    ? `<p style="margin:20px 0;"><a href="${escapeHtmlAttr(lodgely_url)}" style="display:inline-block;padding:10px 18px;background:#6C5CE7;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Open in lodgely</a></p>`
+    : '';
+
   const html = `
     <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;">
       <h2 style="color:#6C5CE7;">New Submission: ${formTitle}</h2>
       <table style="width:100%;border-collapse:collapse;margin:20px 0;">
         ${rows}
       </table>
+      ${lodgelyLink}
       <p style="color:#999;font-size:12px;">Sent by OpenFlow</p>
     </div>
   `;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/IntegrationsPanel.jsx
+++ b/frontend/src/components/IntegrationsPanel.jsx
@@ -28,7 +28,7 @@ export default function IntegrationsPanel({ formId }) {
     const actualType = type === 'google_sheets_sa' ? 'google_sheets' : type;
     const defaults = {
       webhook: { url: '', secret: '', method: 'POST' },
-      email: { smtp_host: '', smtp_port: 587, smtp_user: '', smtp_pass: '', smtp_secure: false, to: '', from: '', subject: '' },
+      email: { smtp_host: '', smtp_port: 587, smtp_user: '', smtp_pass: '', smtp_secure: false, to: '', from: '', subject: '', lodgely_link_enabled: false, lodgely_url: '' },
       google_sheets: { mode: 'apps_script', apps_script_url: '' },
       google_sheets_sa: { mode: 'service_account', credentials_json: '', spreadsheet_id: '', sheet_name: 'Sheet1' },
     };
@@ -223,6 +223,18 @@ function EmailConfig({ config, onChange }) {
         <input type="checkbox" checked={config.smtp_secure || false} onChange={e => onChange('smtp_secure', e.target.checked)} />
         Use SSL/TLS (port 465)
       </label>
+      <div style={{ gridColumn: '1 / -1', borderTop: '1px solid #eee', marginTop: 8, paddingTop: 12 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14, marginBottom: config.lodgely_link_enabled ? 12 : 0 }}>
+          <input type="checkbox" checked={config.lodgely_link_enabled || false} onChange={e => onChange('lodgely_link_enabled', e.target.checked)} />
+          Include a link to lodgely in this email
+        </label>
+        {config.lodgely_link_enabled && (
+          <div className="input-group">
+            <label>lodgely URL</label>
+            <input className="input" value={config.lodgely_url || ''} onChange={e => onChange('lodgely_url', e.target.value)} placeholder="https://lodgely.yourcompany.com" />
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Clients who still prefer email notifications over the lodgely dashboard can now get a direct link to lodgely inside each lead email.
- New per-integration fields on the **Email Notification** integration: `lodgely_link_enabled` (toggle) and `lodgely_url` (the admin's lodgely instance URL). Both are off/empty by default, so existing emails are unaffected until an admin opts in.
- When enabled, `runEmail` in `backend/src/models/integrations.js` appends an "Open in lodgely" button to the HTML email body; the URL is HTML-escaped before being inserted into the `href`/markup.
- `frontend/src/components/IntegrationsPanel.jsx` — the Email Notification config now shows a checkbox ("Include a link to lodgely in this email") that reveals a lodgely URL field when checked.
- Version bump (0.14.0 → 0.15.0) and changelog entry per repo convention.

## Test plan
- [x] `node --check` on the modified backend file
- [x] Ran the backend Jest suite (`npx jest --forceExit`) before and after the change — confirmed the 5 pre-existing failures (in `auth.test.js` and `validation.test.js`) exist on `main` as well and are unrelated to this change
- [ ] Manual verification in the browser (Integrations panel → Email Notification → toggle) — not done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3eywFzBvgpbJxhUwNbZHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3eywFzBvgpbJxhUwNbZHm)_