### PR TITLE
Make lodgely link button text editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.15.1] - 2026-07-02
+
+### Changed
+- **Editable lodgely link button text** — The lodgely link on the Email Notification integration now has an optional "Button text" field, so admins can customize the call-to-action (e.g. "View lead in lodgely") instead of the fixed "Open in lodgely" label. Falls back to "Open in lodgely" when left blank.
+
 ## [0.15.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.15.0
+# 🌊 OpenFlow v0.15.1
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -84,7 +84,7 @@ function escapeHtmlAttr(str) {
 async function runEmail(config, formId, formTitle, data, steps) {
   const {
     smtp_host, smtp_port = 587, smtp_user, smtp_pass, smtp_secure = false, to, from, subject,
-    lodgely_link_enabled, lodgely_url,
+    lodgely_link_enabled, lodgely_url, lodgely_button_text,
   } = config;
 
   if (!smtp_host || !to) throw new Error('SMTP host and recipient are required');
@@ -106,7 +106,7 @@ async function runEmail(config, formId, formTitle, data, steps) {
   }).join('');
 
   const lodgelyLink = lodgely_link_enabled && lodgely_url
-    ? `<p style="margin:20px 0;"><a href="${escapeHtmlAttr(lodgely_url)}" style="display:inline-block;padding:10px 18px;background:#6C5CE7;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">Open in lodgely</a></p>`
+    ? `<p style="margin:20px 0;"><a href="${escapeHtmlAttr(lodgely_url)}" style="display:inline-block;padding:10px 18px;background:#6C5CE7;color:#fff;text-decoration:none;border-radius:6px;font-weight:600;">${escapeHtmlAttr(lodgely_button_text || 'Open in lodgely')}</a></p>`
     : '';
 
   const html = `

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/IntegrationsPanel.jsx
+++ b/frontend/src/components/IntegrationsPanel.jsx
@@ -28,7 +28,7 @@ export default function IntegrationsPanel({ formId }) {
     const actualType = type === 'google_sheets_sa' ? 'google_sheets' : type;
     const defaults = {
       webhook: { url: '', secret: '', method: 'POST' },
-      email: { smtp_host: '', smtp_port: 587, smtp_user: '', smtp_pass: '', smtp_secure: false, to: '', from: '', subject: '', lodgely_link_enabled: false, lodgely_url: '' },
+      email: { smtp_host: '', smtp_port: 587, smtp_user: '', smtp_pass: '', smtp_secure: false, to: '', from: '', subject: '', lodgely_link_enabled: false, lodgely_url: '', lodgely_button_text: '' },
       google_sheets: { mode: 'apps_script', apps_script_url: '' },
       google_sheets_sa: { mode: 'service_account', credentials_json: '', spreadsheet_id: '', sheet_name: 'Sheet1' },
     };
@@ -229,9 +229,15 @@ function EmailConfig({ config, onChange }) {
           Include a link to lodgely in this email
         </label>
         {config.lodgely_link_enabled && (
-          <div className="input-group">
-            <label>lodgely URL</label>
-            <input className="input" value={config.lodgely_url || ''} onChange={e => onChange('lodgely_url', e.target.value)} placeholder="https://lodgely.yourcompany.com" />
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <div className="input-group">
+              <label>lodgely URL</label>
+              <input className="input" value={config.lodgely_url || ''} onChange={e => onChange('lodgely_url', e.target.value)} placeholder="https://lodgely.yourcompany.com" />
+            </div>
+            <div className="input-group">
+              <label>Button text (optional)</label>
+              <input className="input" value={config.lodgely_button_text || ''} onChange={e => onChange('lodgely_button_text', e.target.value)} placeholder="Open in lodgely" />
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Follow-up to #69 (merged) — the "Open in lodgely" button in lead notification emails now has an editable label.
- New optional `lodgely_button_text` field on the Email Notification integration's lodgely config. Falls back to "Open in lodgely" when left blank.
- `backend/src/models/integrations.js` — `runEmail` uses the configured text (HTML-escaped) for the button label.
- `frontend/src/components/IntegrationsPanel.jsx` — a "Button text (optional)" input appears next to the lodgely URL field once the lodgely link toggle is enabled.
- Patch version bump (0.15.0 → 0.15.1) and changelog entry per repo convention.

## Test plan
- [x] `node --check` on the modified backend file
- [x] `npx jest --forceExit` — same 5 pre-existing failures as on `main` (`auth.test.js`, `validation.test.js`), unrelated to this change
- [ ] Manual verification in the browser — not done in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3eywFzBvgpbJxhUwNbZHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3eywFzBvgpbJxhUwNbZHm)_