### PR TITLE
Security hardening: fix critical XSS, auth, and SSRF issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.16.0] - 2026-07-03
+
+### Security
+
+Hardening pass across the app following a full security audit (production deployments store real lead/PII data). No breaking API changes; a few defaults changed to be safe-by-default.
+
+- **No more insecure default secrets** — `JWT_SECRET` is auto-generated and persisted (instead of falling back to a hardcoded string) if not set explicitly, and a missing `ADMIN_PASSWORD` now generates and prints a random one-time password on first boot instead of the well-known `admin123`.
+- **Fixed critical stored XSS** — the GTM container ID field was interpolated unescaped into a raw `<script>` tag on public form/embed pages; it's now validated against `GTM-XXXXXXX` both client- and server-side.
+- **Login brute-force protection** — `/api/auth/login` (and user-invite/token-creation) are now rate limited; only failed login attempts consume the throttle budget, so legitimate rapid logins are unaffected. Login responses no longer leak account existence via timing.
+- **SSRF protection on integrations** — webhook and Google Apps Script URLs are validated to reject private/internal/loopback network destinations before the server fetches them.
+- **CSV export formula-injection fix** — submission export cells starting with `=`, `+`, `-`, or `@` are neutralized so opening the file in Excel/Sheets can't trigger formula execution.
+- **CORS locked down** — replaced the wide-open `origin: true` (any site, with credentials) with an explicit allowlist.
+- **Rate limiter can no longer be bypassed via a spoofed `X-Forwarded-For` header** on unproxied deployments.
+- **Outbound notification emails now HTML-escape submitted field values**, closing an HTML-injection vector in lead emails.
+- **CSS theme customization is sanitized** to strip `@import`/`url()`/`expression()` and block CSS-based data exfiltration.
+- Minimum password length (10 chars) enforced when creating/updating users.
+- `/api/admin/*` is now correctly blocked on per-form public subdomains.
+- Public request body size limits reduced from a blanket 50MB to right-sized per-route limits.
+- WordPress plugin: Gutenberg block rendering no longer round-trips through re-serialized shortcode syntax.
+
 ## [0.15.1] - 2026-07-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.15.1
+# 🌊 OpenFlow v0.16.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -24,8 +24,32 @@ if (process.env.OPENFLOW_PRIMARY_HOST) {
   app.set('trust proxy', 1);
 }
 
-app.use(cors({ origin: true, credentials: true }));
-app.use(express.json({ limit: '50mb' }));
+// The frontend is served by this same app (or proxied same-origin in dev via
+// Vite), so browser requests don't need cross-origin CORS at all. Reflecting
+// any Origin with credentials: true would let any third-party site make
+// authenticated (cookie-carrying) requests against the API. Only allow the
+// explicitly configured origin(s), if any.
+const allowedOrigins = [process.env.OPENFLOW_PRIMARY_HOST, ...(process.env.CORS_ORIGINS || '').split(',')]
+  .map(o => o && o.trim())
+  .filter(Boolean)
+  .flatMap(o => (o.startsWith('http://') || o.startsWith('https://')) ? [o] : [`http://${o}`, `https://${o}`]);
+
+app.use(cors({
+  origin(origin, callback) {
+    if (!origin || allowedOrigins.includes(origin)) return callback(null, true);
+    callback(new Error('Not allowed by CORS'));
+  },
+  credentials: true,
+}));
+// Most JSON bodies are small (form config, integration config, credentials).
+// Two routes legitimately need much more: public submissions can embed
+// base64-encoded file uploads, and admin backup/restore ships the whole DB.
+// Give those a large limit and everything else a small one, so an
+// unauthenticated caller can't exhaust memory/bandwidth by POSTing huge
+// bodies to lightweight endpoints.
+app.use('/api/public/form/:slug/submit', express.json({ limit: '50mb' }));
+app.use('/api/admin/restore', express.json({ limit: '50mb' }));
+app.use(express.json({ limit: '1mb' }));
 app.use(cookieParser());
 
 // Resolve the per-form subdomain (if any) before any other route runs so

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,10 +1,39 @@
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 const { looksLikeApiToken, findByToken, touchLastUsed } = require('../models/apiTokens');
 
-const JWT_SECRET = process.env.JWT_SECRET || 'change-me-in-production';
-if (!process.env.JWT_SECRET) {
-  console.warn('WARNING: JWT_SECRET is not set. Using default insecure secret. Set JWT_SECRET in production!');
+// If JWT_SECRET isn't provided via env, generate a random one and persist it
+// next to the database (same volume as DB_PATH) so it survives restarts.
+// This avoids ever falling back to a hardcoded, publicly-known secret, which
+// would let anyone forge admin session tokens.
+function loadOrCreateJwtSecret() {
+  if (process.env.JWT_SECRET) return process.env.JWT_SECRET;
+
+  const dataDir = path.dirname(process.env.DB_PATH || path.join(__dirname, '../../data/openflow.db'));
+  const secretPath = path.join(dataDir, '.jwt_secret');
+
+  try {
+    if (fs.existsSync(secretPath)) {
+      const existing = fs.readFileSync(secretPath, 'utf8').trim();
+      if (existing) return existing;
+    }
+    fs.mkdirSync(dataDir, { recursive: true });
+    const generated = crypto.randomBytes(48).toString('hex');
+    fs.writeFileSync(secretPath, generated, { mode: 0o600 });
+    console.warn('WARNING: JWT_SECRET is not set. Generated and persisted a random secret at ' + secretPath + '. Set JWT_SECRET explicitly in production to control this.');
+    return generated;
+  } catch (err) {
+    // Can't persist (e.g. read-only filesystem) — fall back to an
+    // in-memory random secret. Sessions won't survive a restart, but at
+    // least no hardcoded/guessable secret is ever used.
+    console.warn('WARNING: JWT_SECRET is not set and could not be persisted (' + err.message + '). Using an ephemeral random secret; all sessions will be invalidated on restart.');
+    return crypto.randomBytes(48).toString('hex');
+  }
 }
+
+const JWT_SECRET = loadOrCreateJwtSecret();
 
 function authMiddleware(req, res, next) {
   const token = req.cookies.token || req.headers.authorization?.replace('Bearer ', '');

--- a/backend/src/middleware/subdomain.js
+++ b/backend/src/middleware/subdomain.js
@@ -25,6 +25,7 @@ const ADMIN_PATH_PREFIXES = [
   '/api/integrations',
   '/api/analytics',
   '/api/settings',
+  '/api/admin',
 ];
 
 function isAdminPath(p) {

--- a/backend/src/models/db.js
+++ b/backend/src/models/db.js
@@ -131,13 +131,28 @@ function initDb() {
 
   // Seed admin user
   const adminEmail = process.env.ADMIN_EMAIL || 'admin@openflow.local';
-  const adminPassword = process.env.ADMIN_PASSWORD || 'admin123';
   const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(adminEmail);
   if (!existing) {
     const { v4: uuid } = require('uuid');
+    // Never fall back to a hardcoded, publicly-documented password
+    // (e.g. 'admin123'). If ADMIN_PASSWORD isn't set, generate a random
+    // one-time password and print it once so the operator can log in and
+    // change it — a leaked/guessed well-known default is a full admin
+    // takeover given this is an internet-reachable, single-tenant app.
+    const crypto = require('crypto');
+    const generatedPassword = !process.env.ADMIN_PASSWORD ? crypto.randomBytes(12).toString('base64url') : null;
+    const adminPassword = process.env.ADMIN_PASSWORD || generatedPassword;
     const hash = bcrypt.hashSync(adminPassword, 10);
     db.prepare("INSERT INTO users (id, email, password_hash, role) VALUES (?, ?, ?, 'admin')").run(uuid(), adminEmail, hash);
-    console.log(`Admin user created: ${adminEmail}`);
+    if (generatedPassword) {
+      console.log('='.repeat(60));
+      console.log(`Admin user created: ${adminEmail}`);
+      console.log(`Generated admin password: ${generatedPassword}`);
+      console.log('Log in and change this password. Set ADMIN_PASSWORD to control it explicitly.');
+      console.log('='.repeat(60));
+    } else {
+      console.log(`Admin user created: ${adminEmail}`);
+    }
   } else {
     // Ensure admin has admin role
     db.prepare("UPDATE users SET role = 'admin' WHERE email = ? AND (role IS NULL OR role != 'admin')").run(adminEmail);

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -1,6 +1,7 @@
 const nodemailer = require('nodemailer');
 const { google } = require('googleapis');
 const { flattenFields } = require('../utils/steps');
+const { assertSafeUrl } = require('../utils/ssrf');
 
 // ──────────────────────────────────────────
 // Run all integrations for a form submission
@@ -46,6 +47,7 @@ async function runIntegrations(db, formId, formTitle, submissionData, steps) {
 async function runWebhook(config, formId, formTitle, data) {
   const { url, secret, method = 'POST' } = config;
   if (!url) throw new Error('Webhook URL is required');
+  await assertSafeUrl(url);
 
   const headers = { 'Content-Type': 'application/json' };
   if (secret) {
@@ -62,8 +64,14 @@ async function runWebhook(config, formId, formTitle, data) {
     headers,
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(10000),
+    // Don't auto-follow redirects: a validated public URL could redirect to
+    // an internal address, bypassing the assertSafeUrl check above.
+    redirect: 'manual',
   });
 
+  if (res.status >= 300 && res.status < 400) {
+    throw new Error('Webhook responded with a redirect, which is not followed for security reasons');
+  }
   if (!res.ok) {
     throw new Error(`Webhook returned ${res.status}: ${await res.text().catch(() => '')}`);
   }
@@ -102,7 +110,7 @@ async function runEmail(config, formId, formTitle, data, steps) {
     if (val === undefined || val === null) val = '-';
     if (typeof val === 'object') val = JSON.stringify(val);
     if (Array.isArray(val)) val = val.join(', ');
-    return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:#555;">${field.label || field.question || field.id}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;">${val}</td></tr>`;
+    return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:#555;">${escapeHtmlAttr(field.label || field.question || field.id)}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;">${escapeHtmlAttr(val)}</td></tr>`;
   }).join('');
 
   const lodgelyLink = lodgely_link_enabled && lodgely_url
@@ -111,7 +119,7 @@ async function runEmail(config, formId, formTitle, data, steps) {
 
   const html = `
     <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;">
-      <h2 style="color:#6C5CE7;">New Submission: ${formTitle}</h2>
+      <h2 style="color:#6C5CE7;">New Submission: ${escapeHtmlAttr(formTitle)}</h2>
       <table style="width:100%;border-collapse:collapse;margin:20px 0;">
         ${rows}
       </table>
@@ -135,6 +143,16 @@ async function runEmail(config, formId, formTitle, data, steps) {
 async function runGoogleSheetsAppsScript(config, formId, formTitle, data, steps) {
   const { apps_script_url } = config;
   if (!apps_script_url) throw new Error('Apps Script URL is required');
+  await assertSafeUrl(apps_script_url);
+  // Apps Script web apps legitimately 302 to script.googleusercontent.com to
+  // serve the execution result, so (unlike the generic webhook) we can't
+  // just refuse to follow redirects — instead restrict the *initial* host to
+  // Google's own domain, which is the only legitimate target for this
+  // integration and can't be pointed at an internal address.
+  const host = new URL(apps_script_url).hostname;
+  if (host !== 'script.google.com') {
+    throw new Error('Apps Script URL must be on script.google.com');
+  }
 
   const payload = {
     formId,

--- a/backend/src/models/rateLimit.js
+++ b/backend/src/models/rateLimit.js
@@ -24,4 +24,13 @@ function checkRateLimit(key, maxRequests, windowSeconds) {
   return entry.count <= maxRequests;
 }
 
-module.exports = { checkRateLimit };
+// Read-only: reports whether the bucket is already over the limit without
+// consuming a request. Used to gate an action before it happens (e.g. reject
+// a login attempt outright) without penalizing successful requests.
+function isRateLimited(key, maxRequests) {
+  const entry = buckets.get(key);
+  if (!entry || Date.now() > entry.expiresAt) return false;
+  return entry.count >= maxRequests;
+}
+
+module.exports = { checkRateLimit, isRateLimited };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -3,8 +3,13 @@ const bcrypt = require('bcryptjs');
 const { getDb } = require('../models/db');
 const { authMiddleware, signToken, requireSession } = require('../middleware/auth');
 const apiTokens = require('../models/apiTokens');
+const { checkRateLimit, isRateLimited } = require('../models/rateLimit');
 
 const router = Router();
+
+function clientIp(req) {
+  return req.ip || req.socket?.remoteAddress || 'unknown';
+}
 
 router.post('/login', (req, res) => {
   const { email, password } = req.body;
@@ -12,9 +17,25 @@ router.post('/login', (req, res) => {
     return res.status(400).json({ error: 'Email and password required' });
   }
 
+  // Throttle by IP and by targeted email so neither a single-source
+  // credential-stuffing run nor a distributed brute-force of one account
+  // can guess passwords unthrottled. Only failed attempts consume the
+  // budget (checked below), so legitimate repeated logins are never
+  // penalized — this only gates callers who are already over the limit.
+  const ipKey = `login-ip:${clientIp(req)}`;
+  const emailKey = `login-email:${String(email).toLowerCase()}`;
+  if (isRateLimited(ipKey, 20) || isRateLimited(emailKey, 10)) {
+    return res.status(429).json({ error: 'Too many login attempts. Try again later.' });
+  }
+
   const db = getDb();
   const user = db.prepare('SELECT * FROM users WHERE email = ?').get(email);
-  if (!user || !bcrypt.compareSync(password, user.password_hash)) {
+  // Always run a bcrypt compare, even for an unknown email, so response
+  // timing doesn't reveal whether an account exists.
+  const passwordOk = bcrypt.compareSync(password, user ? user.password_hash : '$2a$10$invalidsaltinvalidsaltinvalidsalu');
+  if (!user || !passwordOk) {
+    checkRateLimit(ipKey, 20, 60);
+    checkRateLimit(emailKey, 10, 60);
     return res.status(401).json({ error: 'Invalid credentials' });
   }
 
@@ -60,9 +81,16 @@ router.get('/users', authMiddleware, requireAdmin, (req, res) => {
 
 // Create / invite user
 router.post('/users', authMiddleware, requireAdmin, (req, res) => {
+  if (!checkRateLimit(`users-create:${req.userId}`, 20, 60)) {
+    return res.status(429).json({ error: 'Too many requests. Try again later.' });
+  }
+
   const { email, password, role } = req.body;
   if (!email || !password) {
     return res.status(400).json({ error: 'Email and password required' });
+  }
+  if (password.length < 10) {
+    return res.status(400).json({ error: 'Password must be at least 10 characters' });
   }
 
   const db = getDb();
@@ -92,6 +120,9 @@ router.put('/users/:id', authMiddleware, requireAdmin, (req, res) => {
     db.prepare('UPDATE users SET role = ? WHERE id = ?').run(role === 'admin' ? 'admin' : 'user', req.params.id);
   }
   if (password) {
+    if (password.length < 10) {
+      return res.status(400).json({ error: 'Password must be at least 10 characters' });
+    }
     const hash = bcrypt.hashSync(password, 10);
     db.prepare('UPDATE users SET password_hash = ? WHERE id = ?').run(hash, req.params.id);
   }
@@ -131,6 +162,10 @@ router.get('/tokens', authMiddleware, requireSession, (req, res) => {
 
 // Create a token. The plaintext is returned exactly once, here.
 router.post('/tokens', authMiddleware, requireSession, (req, res) => {
+  if (!checkRateLimit(`tokens-create:${req.userId}`, 20, 60)) {
+    return res.status(429).json({ error: 'Too many requests. Try again later.' });
+  }
+
   const name = typeof req.body.name === 'string' ? req.body.name.trim() : '';
   if (!name) {
     return res.status(400).json({ error: 'Token name is required' });

--- a/backend/src/routes/forms.js
+++ b/backend/src/routes/forms.js
@@ -5,9 +5,30 @@ const { v4: uuid } = require('uuid');
 const { customAlphabet } = require('nanoid');
 const { validateSlug } = require('../utils/slug');
 const { validateSubdomain } = require('../utils/subdomain');
+const { sanitizeCss } = require('../utils/sanitizeCss');
+
+function sanitizeTheme(theme) {
+  if (!theme || typeof theme !== 'object') return theme;
+  if (typeof theme.customCss === 'string') {
+    return { ...theme, customCss: sanitizeCss(theme.customCss) };
+  }
+  return theme;
+}
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 8);
 const router = Router();
+
+// GTM container ids are interpolated into a raw <script> tag on the public
+// form/embed pages, so any non-conforming value must be rejected server-side
+// (client-side checks alone aren't enough — this is the actual trust boundary).
+const GTM_ID_RE = /^GTM-[A-Z0-9]+$/;
+function validateGtmId(gtm_id) {
+  if (gtm_id === undefined || gtm_id === null || gtm_id === '') return { ok: true, value: '' };
+  if (typeof gtm_id !== 'string' || !GTM_ID_RE.test(gtm_id)) {
+    return { ok: false, error: 'GTM container ID must look like GTM-XXXXXXX' };
+  }
+  return { ok: true, value: gtm_id };
+}
 
 router.use(authMiddleware);
 
@@ -44,6 +65,9 @@ router.post('/', (req, res) => {
   const slug = nanoid();
   const { title, steps, end_screen, theme, gtm_id } = req.body;
 
+  const gtmCheck = validateGtmId(gtm_id);
+  if (!gtmCheck.ok) return res.status(400).json({ error: gtmCheck.error });
+
   db.prepare(`
     INSERT INTO forms (id, user_id, title, slug, steps, end_screen, theme, gtm_id)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -53,8 +77,8 @@ router.post('/', (req, res) => {
     slug,
     JSON.stringify(steps || []),
     JSON.stringify(end_screen || { title: 'Thank you!', message: 'We will get back to you shortly.' }),
-    JSON.stringify(theme || {}),
-    gtm_id || ''
+    JSON.stringify(sanitizeTheme(theme) || {}),
+    gtmCheck.value
   );
 
   const form = db.prepare('SELECT * FROM forms WHERE id = ?').get(id);
@@ -122,6 +146,11 @@ router.put('/:id', (req, res) => {
   if (!existing) return res.status(404).json({ error: 'Form not found' });
 
   const { title, slug, subdomain, steps, end_screen, theme, gtm_id, published } = req.body;
+
+  if (gtm_id !== undefined) {
+    const gtmCheck = validateGtmId(gtm_id);
+    if (!gtmCheck.ok) return res.status(400).json({ error: gtmCheck.error });
+  }
 
   // Handle subdomain change separately: validate, check uniqueness.
   // null/empty string clears it.
@@ -195,7 +224,7 @@ router.put('/:id', (req, res) => {
     title ?? null,
     steps ? JSON.stringify(steps) : null,
     end_screen ? JSON.stringify(end_screen) : null,
-    theme ? JSON.stringify(theme) : null,
+    theme ? JSON.stringify(sanitizeTheme(theme)) : null,
     gtm_id ?? null,
     published ?? null,
     req.params.id

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -5,6 +5,18 @@ const { v4: uuid } = require('uuid');
 
 const router = Router();
 
+// Only trust X-Forwarded-For when Express's own 'trust proxy' setting is on
+// (index.js only enables it when fronted by a real reverse proxy). Otherwise
+// any client could set this header themselves and pick a fresh rate-limit
+// bucket on every request, defeating the submit/track throttles entirely.
+function clientIp(req) {
+  if (req.app.get('trust proxy')) {
+    const fwd = req.headers['x-forwarded-for'];
+    if (fwd) return fwd.split(',')[0].trim();
+  }
+  return req.ip || req.socket?.remoteAddress || 'unknown';
+}
+
 // Get published form by slug (public)
 router.get('/form/:slug', (req, res) => {
   const db = getDb();
@@ -38,7 +50,7 @@ router.get('/form/:slug', (req, res) => {
 // Submit form response (public)
 router.post('/form/:slug/submit', async (req, res) => {
   // Rate limit: 10 submissions per IP per minute
-  const ip = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.ip || req.socket?.remoteAddress;
+  const ip = clientIp(req);
   const allowed = checkRateLimit(`submit:${ip}`, 10, 60);
   if (!allowed) {
     return res.status(429).json({ error: 'Too many submissions, please try again later' });
@@ -101,7 +113,7 @@ router.post('/form/:slug/submit', async (req, res) => {
 
 // Track analytics event (public, rate limited)
 router.post('/track', (req, res) => {
-  const ip = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.ip || req.socket?.remoteAddress;
+  const ip = clientIp(req);
   const allowed = checkRateLimit(`track:${ip}`, 100, 60);
   if (!allowed) return res.status(429).json({ error: 'Rate limited' });
 

--- a/backend/src/routes/submissions.js
+++ b/backend/src/routes/submissions.js
@@ -49,8 +49,16 @@ router.get('/:formId/export', (req, res) => {
     return [s.created_at, ...fields.map(f => data[f.id] ?? '')];
   });
 
+  // Neutralize CSV/DDE formula injection: if a cell starts with a character
+  // spreadsheet apps treat as a formula prefix, prepend a single quote so it
+  // opens as text instead of executing when the exported file is opened.
+  const neutralizeFormula = (cell) => {
+    const str = String(cell);
+    return /^[=+\-@\t\r]/.test(str) ? `'${str}` : str;
+  };
+
   const csv = [headers, ...rows].map(row =>
-    row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(',')
+    row.map(cell => `"${neutralizeFormula(cell).replace(/"/g, '""')}"`).join(',')
   ).join('\n');
 
   res.setHeader('Content-Type', 'text/csv');

--- a/backend/src/utils/sanitizeCss.js
+++ b/backend/src/utils/sanitizeCss.js
@@ -1,0 +1,18 @@
+// Strips constructs from user-supplied CSS that can be used to exfiltrate
+// data or load external resources: @import, url(...) (attribute/CSS
+// exfiltration and remote stylesheet loading), old IE expression()/behavior,
+// and any raw "javascript:" reference. This is a blunt allow-most/strip-a-few
+// filter, not a full CSS parser — it favors keeping the feature usable
+// (colors, fonts, spacing) over completeness.
+function sanitizeCss(css) {
+  if (typeof css !== 'string') return '';
+  return css
+    .replace(/@import[^;]*;?/gi, '')
+    .replace(/url\s*\([^)]*\)/gi, '')
+    .replace(/expression\s*\([^)]*\)/gi, '')
+    .replace(/behavior\s*:[^;]*;?/gi, '')
+    .replace(/javascript\s*:/gi, '')
+    .replace(/<\/?script[^>]*>/gi, '');
+}
+
+module.exports = { sanitizeCss };

--- a/backend/src/utils/ssrf.js
+++ b/backend/src/utils/ssrf.js
@@ -1,0 +1,74 @@
+const dns = require('dns').promises;
+const net = require('net');
+
+// Blocks outbound integration requests (webhooks, Apps Script) from reaching
+// internal/private network destinations. Without this, any user who can
+// configure an integration can make the server fetch cloud metadata
+// endpoints (169.254.169.254), localhost services, or other internal-only
+// hosts on its behalf (SSRF).
+
+function ipInCidr(ip, cidr) {
+  const [range, bits] = cidr.split('/');
+  const mask = ~(2 ** (32 - Number(bits)) - 1);
+  return (ip2long(ip) & mask) === (ip2long(range) & mask);
+}
+
+function ip2long(ip) {
+  return ip.split('.').reduce((acc, octet) => (acc << 8) + Number(octet), 0) >>> 0;
+}
+
+const PRIVATE_V4_CIDRS = [
+  '0.0.0.0/8', '10.0.0.0/8', '100.64.0.0/10', '127.0.0.0/8', '169.254.0.0/16',
+  '172.16.0.0/12', '192.0.0.0/24', '192.0.2.0/24', '192.88.99.0/24',
+  '192.168.0.0/16', '198.18.0.0/15', '198.51.100.0/24', '203.0.113.0/24',
+  '224.0.0.0/4', '240.0.0.0/4',
+];
+
+function isPrivateIp(ip) {
+  if (net.isIPv4(ip)) {
+    return PRIVATE_V4_CIDRS.some(cidr => ipInCidr(ip, cidr));
+  }
+  if (net.isIPv6(ip)) {
+    const lower = ip.toLowerCase();
+    if (lower === '::1' || lower === '::') return true;
+    if (lower.startsWith('fe80:') || lower.startsWith('fc') || lower.startsWith('fd')) return true;
+    // IPv4-mapped IPv6 (::ffff:a.b.c.d) — check the embedded v4 address too.
+    const v4Mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (v4Mapped) return isPrivateIp(v4Mapped[1]);
+    return false;
+  }
+  return true; // unknown format — fail closed
+}
+
+/**
+ * Throws if `urlString` is not a safe destination for a server-initiated
+ * outbound request: must be http(s), and must not resolve to a private,
+ * loopback, link-local, or otherwise internal IP address.
+ */
+async function assertSafeUrl(urlString) {
+  let url;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Only http/https URLs are allowed');
+  }
+  const hostname = url.hostname;
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    throw new Error('Requests to localhost are not allowed');
+  }
+
+  let addresses;
+  try {
+    addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new Error('Could not resolve URL host');
+  }
+  if (addresses.length === 0 || addresses.some(a => isPrivateIp(a.address))) {
+    throw new Error('This URL resolves to a private/internal address and cannot be used');
+  }
+}
+
+module.exports = { assertSafeUrl, isPrivateIp };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.13.1",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.13.1",
+      "version": "0.15.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/EmbedView.jsx
+++ b/frontend/src/pages/EmbedView.jsx
@@ -87,6 +87,7 @@ export default function EmbedView() {
   // Inject GTM only when consent is given
   useEffect(() => {
     if (!form?.gtm_id || cookieConsent !== true) return;
+    if (!/^GTM-[A-Z0-9]+$/.test(form.gtm_id)) return;
     const script = document.createElement('script');
     script.innerHTML = `
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/frontend/src/pages/FormView.jsx
+++ b/frontend/src/pages/FormView.jsx
@@ -91,6 +91,7 @@ export default function FormView({ slugProp, hostMode = false }) {
   // Inject GTM only when consent is given
   useEffect(() => {
     if (!form?.gtm_id || cookieConsent !== true) return;
+    if (!/^GTM-[A-Z0-9]+$/.test(form.gtm_id)) return;
     const script = document.createElement('script');
     script.innerHTML = `
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/wordpress-plugin/openflow/openflow.php
+++ b/wordpress-plugin/openflow/openflow.php
@@ -236,10 +236,23 @@ function openflow_register_gutenberg_block(): void
 
 function openflow_gutenberg_render_callback(array $atts): string
 {
-    return do_shortcode(sprintf(
-        '[openflow slug="%s" height="%s" autoresize="%s"]',
-        sanitize_text_field($atts['slug'] ?? ''),
-        absint($atts['height'] ?? 600),
-        ($atts['autoresize'] ?? true) ? 'true' : 'false'
-    ));
+    if (empty($atts['slug'])) {
+        return '<!-- OpenFlow: No form slug provided -->';
+    }
+
+    $server_url = get_option('openflow_server_url', '');
+    if (empty($server_url)) {
+        return '<!-- OpenFlow: Server URL not configured. Go to Settings > OpenFlow -->';
+    }
+
+    // Build the embed HTML directly rather than round-tripping through a
+    // re-serialized shortcode string — sanitize_text_field() doesn't escape
+    // quotes/brackets, so interpolating attribute values into shortcode
+    // syntax and re-parsing it is fragile (shortcode-injection risk if more
+    // shortcodes are ever combined this way).
+    return openflow_generate_embed_html([
+        'slug'       => $atts['slug'] ?? '',
+        'height'     => $atts['height'] ?? 600,
+        'autoresize' => ($atts['autoresize'] ?? true) ? 'true' : 'false',
+    ], $server_url);
 }


### PR DESCRIPTION
## Summary

Full security audit of OpenFlow (backend + frontend + WordPress plugin) since it's now handling production lead/PII data. Two parallel audits (backend, frontend/WP) surfaced 15 findings; all are fixed here. No breaking API changes, but a few defaults changed to be safe-by-default.

### Critical
- **Stored XSS via `gtm_id`** — the GTM container ID was interpolated unescaped into a raw `<script>` tag rendered on every public form/embed page visit. Now validated against `^GTM-[A-Z0-9]+$` both client- and server-side. (`FormView.jsx`, `EmbedView.jsx`, `routes/forms.js`)
- **Insecure default secrets** — `JWT_SECRET` fell back to the literal string `'change-me-in-production'`, and the seeded admin account used the documented default `admin123` if `ADMIN_PASSWORD` wasn't set. Both now generate and persist a random secret/password on first boot instead. (`middleware/auth.js`, `models/db.js`)

### High
- **No brute-force protection on login** — `/api/auth/login` now rate-limits by IP and by targeted email; only *failed* attempts consume the budget, so legitimate rapid logins (and the test suite) are unaffected. Login timing no longer leaks account existence.
- **SSRF via webhook/Apps Script integration URLs** — server-side requests are now validated to reject private/loopback/link-local destinations before fetching; Apps Script URLs are additionally restricted to `script.google.com`. (`utils/ssrf.js`, `models/integrations.js`)
- **CSV formula injection** in submissions export — cells starting with `=`, `+`, `-`, `@` are now neutralized.

### Medium
- **Wide-open CORS** (`origin: true` + `credentials: true`) replaced with an explicit allowlist.
- **Rate limiter bypass via spoofed `X-Forwarded-For`** on unproxied deployments — now only trusted when Express's own `trust proxy` is enabled.
- **Unescaped submission data in outbound notification emails** — now HTML-escaped.
- **CSS injection via `theme.customCss`** enabling cross-field data exfiltration — sanitized to strip `@import`/`url()`/`expression()`.

### Low
- Minimum password length (10 chars) enforced on user create/update.
- `/api/admin/*` added to the per-form-subdomain admin-path blocklist (was previously reachable there).
- Public JSON body size limit reduced from a blanket 50MB to right-sized per-route limits (file-upload submissions and DB restore keep 50MB; everything else gets 1MB).
- WordPress plugin: Gutenberg block rendering no longer round-trips through re-serialized shortcode syntax (quote/bracket escaping gap).

## Test plan
- [x] Backend Jest suite (`npm test`) — same 5 pre-existing failures as the `main` baseline, no new regressions introduced by this change
- [x] Frontend production build (`npm run build`) succeeds
- [x] Verified module loading for all touched backend files
- [ ] Manual smoke test of login, form publish/submit, and integrations in a running instance (not performed in this environment)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_016t5Q8rioewSgr7wKMi3bQ1)_