### PR TITLE
Add scheduled backups and retrying integration deliveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.17.0] - 2026-07-03
+
+### Added
+- **Scheduled backups** — a background scheduler writes a full DB backup on an interval (`BACKUP_INTERVAL_HOURS`, default 24h) with automatic pruning (`BACKUP_RETENTION_COUNT`, default 14), so recovery no longer depends on someone remembering to click "Download backup". `docker-compose.yml` now mounts a separate `./backups` bind mount (`BACKUP_DIR`) so backups survive even if the `db-data` volume is lost or corrupted. New admin endpoints `GET /api/admin/backups` and `GET /api/admin/backups/:filename` list/download scheduled backups. Set `BACKUP_ENABLED=false` to disable.
+- **Retrying integration deliveries with dead-letter visibility** — submissions to a form with a webhook/email/Google Sheets integration are now persisted as a delivery record before being sent. A failed delivery (client webhook down, SMTP hiccup) is retried with backoff (1m/5m/30m/2h/6h) instead of being silently dropped; after all retries are exhausted it's marked as a dead letter. The Integrations tab shows a banner for any failing/dead deliveries with a manual "Retry now" action, so a bad campaign lead can't vanish unnoticed. New endpoints: `GET /api/integrations/:formId/deliveries`, `POST /api/integrations/:formId/deliveries/:deliveryId/retry`.
+
 ## [0.16.2] - 2026-07-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.16.2
+# 🌊 OpenFlow v0.17.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.15.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,7 +2,9 @@ const express = require('express');
 const cookieParser = require('cookie-parser');
 const path = require('path');
 const { version } = require('../package.json');
-const { initDb } = require('./models/db');
+const { initDb, getDb } = require('./models/db');
+const { startBackupScheduler } = require('./models/backupScheduler');
+const { startDeliveryWorker } = require('./models/deliveryQueue');
 const authRoutes = require('./routes/auth');
 const formRoutes = require('./routes/forms');
 const submissionRoutes = require('./routes/submissions');
@@ -143,6 +145,9 @@ async function start() {
     console.error('Database initialization failed:', err.message);
     process.exit(1);
   }
+
+  startBackupScheduler(getDb());
+  startDeliveryWorker(getDb());
 
   app.listen(PORT, '0.0.0.0', () => {
     console.log(`OpenFlow running on http://0.0.0.0:${PORT}`);

--- a/backend/src/models/backupScheduler.js
+++ b/backend/src/models/backupScheduler.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const { createBackup } = require('./backup');
+
+// Where scheduled backups land. Defaults next to the DB file so it rides
+// along in the existing `db-data` volume out of the box, but operators can
+// point BACKUP_DIR at a separately-mounted volume/bind-mount for real
+// off-box protection (a volume-level disaster takes both the DB and a
+// same-volume backup down together).
+function backupDir() {
+  return process.env.BACKUP_DIR || path.join(path.dirname(process.env.DB_PATH || path.join(__dirname, '../../data/openflow.db')), 'backups');
+}
+
+function writeScheduledBackup(db) {
+  const dir = backupDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const backup = createBackup(db);
+  const filename = `openflow-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+  fs.writeFileSync(path.join(dir, filename), JSON.stringify(backup));
+  return filename;
+}
+
+function pruneOldBackups(retentionCount) {
+  const dir = backupDir();
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter(f => f.startsWith('openflow-backup-') && f.endsWith('.json'));
+  } catch {
+    return;
+  }
+  files.sort();
+  const excess = files.length - retentionCount;
+  for (let i = 0; i < excess; i++) {
+    fs.unlinkSync(path.join(dir, files[i]));
+  }
+}
+
+function listScheduledBackups() {
+  const dir = backupDir();
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter(f => f.startsWith('openflow-backup-') && f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  return files
+    .map(filename => {
+      const stat = fs.statSync(path.join(dir, filename));
+      return { filename, size: stat.size, created_at: stat.mtime.toISOString() };
+    })
+    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+}
+
+// Filename must come from listScheduledBackups (or match its exact format)
+// before being used to build a filesystem path, so a caller can't traverse
+// out of the backups directory.
+function isValidBackupFilename(filename) {
+  return /^openflow-backup-[\w.-]+\.json$/.test(filename) && !filename.includes('..');
+}
+
+function readScheduledBackup(filename) {
+  if (!isValidBackupFilename(filename)) throw new Error('Invalid backup filename');
+  return fs.readFileSync(path.join(backupDir(), filename));
+}
+
+function startBackupScheduler(db) {
+  if (process.env.BACKUP_ENABLED === 'false') {
+    console.log('Scheduled backups disabled (BACKUP_ENABLED=false)');
+    return null;
+  }
+  const intervalHours = Number(process.env.BACKUP_INTERVAL_HOURS) > 0 ? Number(process.env.BACKUP_INTERVAL_HOURS) : 24;
+  const retentionCount = Number(process.env.BACKUP_RETENTION_COUNT) > 0 ? Number(process.env.BACKUP_RETENTION_COUNT) : 14;
+
+  const run = () => {
+    try {
+      const filename = writeScheduledBackup(db);
+      pruneOldBackups(retentionCount);
+      console.log(`Scheduled backup written: ${filename}`);
+    } catch (err) {
+      console.error('Scheduled backup failed:', err.message);
+    }
+  };
+
+  run();
+  const timer = setInterval(run, intervalHours * 60 * 60 * 1000);
+  timer.unref();
+  console.log(`Scheduled backups enabled: every ${intervalHours}h, keeping last ${retentionCount}, dir=${backupDir()}`);
+  return timer;
+}
+
+module.exports = { startBackupScheduler, listScheduledBackups, readScheduledBackup, backupDir };

--- a/backend/src/models/db.js
+++ b/backend/src/models/db.js
@@ -108,6 +108,29 @@ function initDb() {
     );
 
     CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
+
+    -- Tracks each attempt to deliver a submission to a form's integrations
+    -- (webhook/email/Sheets) so a transient failure (client's endpoint down,
+    -- SMTP hiccup) retries with backoff instead of silently losing the lead,
+    -- and surfaces as a dead letter for manual retry if all attempts fail.
+    CREATE TABLE IF NOT EXISTS integration_deliveries (
+      id TEXT PRIMARY KEY,
+      form_id TEXT NOT NULL,
+      integration_id TEXT NOT NULL,
+      submission_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      attempts INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      next_attempt_at TEXT DEFAULT (datetime('now')),
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (form_id) REFERENCES forms(id),
+      FOREIGN KEY (integration_id) REFERENCES integrations(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_deliveries_form ON integration_deliveries(form_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_deliveries_due ON integration_deliveries(status, next_attempt_at);
   `);
 
   // Migrate: add role column if missing (existing DBs)

--- a/backend/src/models/deliveryQueue.js
+++ b/backend/src/models/deliveryQueue.js
@@ -1,0 +1,127 @@
+const { v4: uuid } = require('uuid');
+const { runIntegration } = require('./integrations');
+
+// Backoff schedule (minutes) between delivery attempts. After the last entry
+// is exhausted the delivery is marked 'dead' for manual retry — a lead
+// should never be silently dropped just because a client's endpoint had a
+// bad minute during a campaign.
+const RETRY_DELAYS_MINUTES = [1, 5, 30, 120, 360];
+const MAX_ATTEMPTS = RETRY_DELAYS_MINUTES.length;
+
+function inMinutes(n) {
+  return new Date(Date.now() + n * 60000).toISOString();
+}
+
+// Enqueue one delivery row per enabled integration and attempt each
+// immediately, so the common (success) case has no added latency. Failures
+// are persisted with a next_attempt_at so the background worker retries
+// them instead of losing the submission.
+async function enqueueAndAttempt(db, formId, formTitle, submissionId, data, steps) {
+  const integrations = db.prepare(
+    'SELECT * FROM integrations WHERE form_id = ? AND enabled = 1'
+  ).all(formId);
+
+  for (const integration of integrations) {
+    const deliveryId = uuid();
+    db.prepare(
+      `INSERT INTO integration_deliveries (id, form_id, integration_id, submission_id, type, status)
+       VALUES (?, ?, ?, ?, ?, 'pending')`
+    ).run(deliveryId, formId, integration.id, submissionId, integration.type);
+
+    await attemptDelivery(db, { id: deliveryId, integration, formId, formTitle, data, steps });
+  }
+}
+
+async function attemptDelivery(db, { id, integration, formId, formTitle, data, steps }) {
+  try {
+    await runIntegration(integration, formId, formTitle, data, steps);
+    db.prepare(
+      `UPDATE integration_deliveries SET status = 'success', updated_at = datetime('now') WHERE id = ?`
+    ).run(id);
+  } catch (err) {
+    const row = db.prepare('SELECT attempts FROM integration_deliveries WHERE id = ?').get(id);
+    const attempts = (row ? row.attempts : 0) + 1;
+    const message = String(err.message || err).slice(0, 2000);
+    if (attempts >= MAX_ATTEMPTS) {
+      db.prepare(
+        `UPDATE integration_deliveries
+         SET status = 'dead', attempts = ?, last_error = ?, updated_at = datetime('now')
+         WHERE id = ?`
+      ).run(attempts, message, id);
+      console.error(`Integration ${integration.type}/${integration.id} exhausted retries:`, message);
+    } else {
+      db.prepare(
+        `UPDATE integration_deliveries
+         SET status = 'retrying', attempts = ?, last_error = ?, next_attempt_at = ?, updated_at = datetime('now')
+         WHERE id = ?`
+      ).run(attempts, message, inMinutes(RETRY_DELAYS_MINUTES[attempts - 1]), id);
+    }
+  }
+}
+
+// Background sweep: re-attempt any delivery whose retry time has arrived.
+// Re-parses the submission's stored data/steps so this works across process
+// restarts (the queue only lives in SQLite, not in memory).
+async function processDueDeliveries(db) {
+  const due = db.prepare(
+    `SELECT d.*, s.data AS submission_data, f.title AS form_title, f.steps AS form_steps
+     FROM integration_deliveries d
+     JOIN submissions s ON s.id = d.submission_id
+     JOIN forms f ON f.id = d.form_id
+     WHERE d.status = 'retrying' AND d.next_attempt_at <= datetime('now')`
+  ).all();
+
+  for (const row of due) {
+    const integration = db.prepare('SELECT * FROM integrations WHERE id = ?').get(row.integration_id);
+    if (!integration || !integration.enabled) {
+      db.prepare(
+        `UPDATE integration_deliveries SET status = 'dead', last_error = 'Integration was disabled or removed', updated_at = datetime('now') WHERE id = ?`
+      ).run(row.id);
+      continue;
+    }
+    await attemptDelivery(db, {
+      id: row.id,
+      integration,
+      formId: row.form_id,
+      formTitle: row.form_title,
+      data: JSON.parse(row.submission_data),
+      steps: JSON.parse(row.form_steps),
+    });
+  }
+}
+
+// Manual retry of a dead (or still-retrying) delivery, e.g. after the client
+// fixes their webhook endpoint.
+async function retryDelivery(db, deliveryId) {
+  const row = db.prepare(
+    `SELECT d.*, s.data AS submission_data, f.title AS form_title, f.steps AS form_steps
+     FROM integration_deliveries d
+     JOIN submissions s ON s.id = d.submission_id
+     JOIN forms f ON f.id = d.form_id
+     WHERE d.id = ?`
+  ).get(deliveryId);
+  if (!row) throw new Error('Delivery not found');
+
+  const integration = db.prepare('SELECT * FROM integrations WHERE id = ?').get(row.integration_id);
+  if (!integration) throw new Error('Integration no longer exists');
+
+  await attemptDelivery(db, {
+    id: row.id,
+    integration,
+    formId: row.form_id,
+    formTitle: row.form_title,
+    data: JSON.parse(row.submission_data),
+    steps: JSON.parse(row.form_steps),
+  });
+  return db.prepare('SELECT * FROM integration_deliveries WHERE id = ?').get(deliveryId);
+}
+
+function startDeliveryWorker(db, intervalMs = 30000) {
+  const timer = setInterval(() => {
+    processDueDeliveries(db).catch(err => console.error('Delivery worker sweep failed:', err.message));
+  }, intervalMs);
+  timer.unref();
+  return timer;
+}
+
+module.exports = { enqueueAndAttempt, processDueDeliveries, retryDelivery, startDeliveryWorker };

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -7,6 +7,26 @@ const { assertSafeUrl } = require('../utils/ssrf');
 // Run all integrations for a form submission
 // ──────────────────────────────────────────
 
+// Run a single integration against a submission. Throws on failure so
+// callers (immediate fire-and-forget, or the retrying delivery queue) can
+// each decide how to handle/record the error.
+async function runIntegration(integration, formId, formTitle, submissionData, steps) {
+  const config = JSON.parse(integration.config);
+  switch (integration.type) {
+    case 'webhook':
+      return runWebhook(config, formId, formTitle, submissionData);
+    case 'email':
+      return runEmail(config, formId, formTitle, submissionData, steps);
+    case 'google_sheets':
+      if (config.mode === 'apps_script') {
+        return runGoogleSheetsAppsScript(config, formId, formTitle, submissionData, steps);
+      }
+      return runGoogleSheets(config, formId, submissionData, steps);
+    default:
+      throw new Error(`Unknown integration type: ${integration.type}`);
+  }
+}
+
 async function runIntegrations(db, formId, formTitle, submissionData, steps) {
   const integrations = db.prepare(
     'SELECT * FROM integrations WHERE form_id = ? AND enabled = 1'
@@ -15,22 +35,7 @@ async function runIntegrations(db, formId, formTitle, submissionData, steps) {
   const results = [];
   for (const integration of integrations) {
     try {
-      const config = JSON.parse(integration.config);
-      switch (integration.type) {
-        case 'webhook':
-          await runWebhook(config, formId, formTitle, submissionData);
-          break;
-        case 'email':
-          await runEmail(config, formId, formTitle, submissionData, steps);
-          break;
-        case 'google_sheets':
-          if (config.mode === 'apps_script') {
-            await runGoogleSheetsAppsScript(config, formId, formTitle, submissionData, steps);
-          } else {
-            await runGoogleSheets(config, formId, submissionData, steps);
-          }
-          break;
-      }
+      await runIntegration(integration, formId, formTitle, submissionData, steps);
       results.push({ id: integration.id, type: integration.type, ok: true });
     } catch (err) {
       console.error(`Integration ${integration.type}/${integration.id} failed:`, err.message);
@@ -236,4 +241,4 @@ async function runGoogleSheets(config, formId, data, steps) {
   });
 }
 
-module.exports = { runIntegrations };
+module.exports = { runIntegrations, runIntegration };

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -2,6 +2,7 @@ const { Router } = require('express');
 const { getDb } = require('../models/db');
 const { authMiddleware, requireAdmin } = require('../middleware/auth');
 const { createBackup, backupSummary, restoreBackup } = require('../models/backup');
+const { listScheduledBackups, readScheduledBackup } = require('../models/backupScheduler');
 
 const router = Router();
 
@@ -20,6 +21,23 @@ router.get('/backup', (req, res) => {
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
   res.setHeader('Content-Disposition', `attachment; filename="openflow-backup-${date}.json"`);
   res.send(JSON.stringify(backup, null, 2));
+});
+
+// List backups written by the automatic scheduler (see BACKUP_* env vars).
+router.get('/backups', (req, res) => {
+  res.json({ backups: listScheduledBackups() });
+});
+
+// Download one specific scheduled backup by filename.
+router.get('/backups/:filename', (req, res) => {
+  try {
+    const contents = readScheduledBackup(req.params.filename);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${req.params.filename}"`);
+    res.send(contents);
+  } catch (err) {
+    res.status(404).json({ error: 'Backup not found' });
+  }
 });
 
 // Restore (replace) the database from an uploaded backup. The backup is

--- a/backend/src/routes/integrations.js
+++ b/backend/src/routes/integrations.js
@@ -102,4 +102,37 @@ router.post('/:formId/:integrationId/test', async (req, res) => {
   }
 });
 
+// List delivery attempts for a form's integrations, most recent first. Lets
+// the dashboard surface failed/dead leads instead of them vanishing silently.
+router.get('/:formId/deliveries', (req, res) => {
+  const db = getDb();
+  const form = db.prepare('SELECT id FROM forms WHERE id = ? AND user_id = ?').get(req.params.formId, req.userId);
+  if (!form) return res.status(404).json({ error: 'Form not found' });
+
+  const deliveries = db.prepare(
+    `SELECT id, integration_id, submission_id, type, status, attempts, last_error, next_attempt_at, created_at, updated_at
+     FROM integration_deliveries WHERE form_id = ? ORDER BY created_at DESC LIMIT 100`
+  ).all(req.params.formId);
+  res.json({ deliveries });
+});
+
+// Manually retry a failed/dead delivery (e.g. after the client fixes their
+// endpoint).
+router.post('/:formId/deliveries/:deliveryId/retry', async (req, res) => {
+  const db = getDb();
+  const form = db.prepare('SELECT id FROM forms WHERE id = ? AND user_id = ?').get(req.params.formId, req.userId);
+  if (!form) return res.status(404).json({ error: 'Form not found' });
+
+  const existing = db.prepare('SELECT id FROM integration_deliveries WHERE id = ? AND form_id = ?').get(req.params.deliveryId, req.params.formId);
+  if (!existing) return res.status(404).json({ error: 'Delivery not found' });
+
+  const { retryDelivery } = require('../models/deliveryQueue');
+  try {
+    const delivery = await retryDelivery(db, req.params.deliveryId);
+    res.json({ delivery });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 module.exports = router;

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -104,10 +104,12 @@ router.post('/form/:slug/submit', async (req, res) => {
 
   res.status(201).json({ ok: true, id });
 
-  // Run integrations async (don't block response)
-  const { runIntegrations } = require('../models/integrations');
-  runIntegrations(db, form.id, form.title, data, steps).catch(err => {
-    console.error('Integration execution error:', err.message);
+  // Deliver to integrations async (don't block response). Each delivery is
+  // persisted first, so a failure (client webhook down, SMTP hiccup) retries
+  // with backoff instead of silently losing the lead.
+  const { enqueueAndAttempt } = require('../models/deliveryQueue');
+  enqueueAndAttempt(db, form.id, form.title, id, data, steps).catch(err => {
+    console.error('Integration delivery error:', err.message);
   });
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,17 @@ services:
       - JWT_SECRET=${JWT_SECRET:-change-me-in-production}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@openflow.local}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin123}
+      # Scheduled backups: written every BACKUP_INTERVAL_HOURS, keeping the
+      # last BACKUP_RETENTION_COUNT. BACKUP_DIR below points at a bind mount
+      # (./backups on the host) instead of the db-data volume, so a lost or
+      # corrupted db-data volume doesn't take the backups down with it. Copy
+      # ./backups off this host regularly for real disaster recovery.
+      - BACKUP_DIR=/app/backups
+      - BACKUP_INTERVAL_HOURS=${BACKUP_INTERVAL_HOURS:-24}
+      - BACKUP_RETENTION_COUNT=${BACKUP_RETENTION_COUNT:-14}
     volumes:
       - db-data:/app/data
+      - ./backups:/app/backups
     restart: unless-stopped
 
 volumes:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -45,6 +45,8 @@ export const api = {
   updateIntegration: (formId, id, data) => request(`/integrations/${formId}/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteIntegration: (formId, id) => request(`/integrations/${formId}/${id}`, { method: 'DELETE' }),
   testIntegration: (formId, id) => request(`/integrations/${formId}/${id}/test`, { method: 'POST' }),
+  getDeliveries: (formId) => request(`/integrations/${formId}/deliveries`),
+  retryDelivery: (formId, deliveryId) => request(`/integrations/${formId}/deliveries/${deliveryId}/retry`, { method: 'POST' }),
 
   // API tokens (read-only programmatic access, e.g. the lodgely connector)
   getApiTokens: () => request('/auth/tokens'),

--- a/frontend/src/components/IntegrationsPanel.jsx
+++ b/frontend/src/components/IntegrationsPanel.jsx
@@ -14,12 +14,41 @@ export default function IntegrationsPanel({ formId }) {
   const [testing, setTesting] = useState(null);
   const [testResult, setTestResult] = useState(null);
   const [error, setError] = useState('');
+  const [deliveries, setDeliveries] = useState([]);
+  const [showDeliveries, setShowDeliveries] = useState(false);
+  const [retrying, setRetrying] = useState(null);
 
   useEffect(() => {
     api.getIntegrations(formId)
       .then(d => setIntegrations(d.integrations))
       .catch(err => setError(err.message || 'Failed to load integrations'));
   }, [formId]);
+
+  function loadDeliveries() {
+    api.getDeliveries(formId).then(d => setDeliveries(d.deliveries)).catch(() => {});
+  }
+
+  // Poll periodically so a dead delivery (client's webhook down) surfaces
+  // without the user needing to refresh the page during a live campaign.
+  useEffect(() => {
+    loadDeliveries();
+    const timer = setInterval(loadDeliveries, 30000);
+    return () => clearInterval(timer);
+  }, [formId]);
+
+  async function retryDelivery(id) {
+    setRetrying(id);
+    try {
+      await api.retryDelivery(formId, id);
+      loadDeliveries();
+    } catch (err) {
+      setError(err.message || 'Retry failed');
+    } finally {
+      setRetrying(null);
+    }
+  }
+
+  const failedDeliveries = deliveries.filter(d => d.status === 'dead' || d.status === 'retrying');
 
   async function addIntegration(type) {
     if (adding) return;
@@ -87,6 +116,47 @@ export default function IntegrationsPanel({ formId }) {
       {error && (
         <div style={{ padding: '10px 16px', marginBottom: 16, borderRadius: 8, background: '#FDEDEC', color: '#E17055', fontSize: 14 }}>
           {error}
+        </div>
+      )}
+
+      {failedDeliveries.length > 0 && (
+        <div className="card" style={{ marginBottom: 16, borderLeft: '4px solid #E17055' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <strong style={{ color: '#E17055' }}>
+              {failedDeliveries.length} lead{failedDeliveries.length > 1 ? 's' : ''} failed to deliver to an integration
+            </strong>
+            <button className="btn btn-sm btn-secondary" onClick={() => setShowDeliveries(s => !s)}>
+              {showDeliveries ? 'Hide' : 'Show'} details
+            </button>
+          </div>
+          {showDeliveries && (
+            <table style={{ width: '100%', marginTop: 12, fontSize: 13, borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ textAlign: 'left', color: '#636E72' }}>
+                  <th style={{ padding: '4px 8px' }}>Type</th>
+                  <th style={{ padding: '4px 8px' }}>Status</th>
+                  <th style={{ padding: '4px 8px' }}>Attempts</th>
+                  <th style={{ padding: '4px 8px' }}>Error</th>
+                  <th style={{ padding: '4px 8px' }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {failedDeliveries.map(d => (
+                  <tr key={d.id} style={{ borderTop: '1px solid #eee' }}>
+                    <td style={{ padding: '4px 8px' }}>{d.type}</td>
+                    <td style={{ padding: '4px 8px' }}>{d.status === 'dead' ? 'Failed (gave up)' : 'Retrying'}</td>
+                    <td style={{ padding: '4px 8px' }}>{d.attempts}</td>
+                    <td style={{ padding: '4px 8px', color: '#E17055' }}>{d.last_error || '-'}</td>
+                    <td style={{ padding: '4px 8px' }}>
+                      <button className="btn btn-sm btn-secondary" disabled={retrying === d.id} onClick={() => retryDelivery(d.id)}>
+                        {retrying === d.id ? 'Retrying...' : 'Retry now'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Production safety follow-up for clients running paid ad campaigns through OpenFlow — two silent-failure gaps closed:

- **Scheduled backups**: a background scheduler (`backend/src/models/backupScheduler.js`) writes a full DB backup every `BACKUP_INTERVAL_HOURS` (default 24h) with automatic pruning (`BACKUP_RETENTION_COUNT`, default 14). `docker-compose.yml` now bind-mounts `./backups` (`BACKUP_DIR`) separately from the `db-data` volume, so a lost/corrupted DB volume doesn't take backups down with it. New admin endpoints: `GET /api/admin/backups`, `GET /api/admin/backups/:filename`. Disable with `BACKUP_ENABLED=false`.
- **Retrying integration deliveries with dead-letter visibility**: submissions to a form's webhook/email/Google Sheets integrations are now persisted as delivery rows (`integration_deliveries` table) before sending, instead of fire-and-forget. A failed delivery retries with backoff (1m/5m/30m/2h/6h) via a background worker; after all attempts are exhausted it's marked `dead` instead of silently disappearing. The Integrations tab shows a banner for any failing/dead deliveries with per-row error and a "Retry now" action. New endpoints: `GET /api/integrations/:formId/deliveries`, `POST /api/integrations/:formId/deliveries/:deliveryId/retry`.

## Test plan

- [x] `npm test` in `backend/` — 109/114 passing; the 5 failures are pre-existing on `main` (unrelated `auth.test.js` DELETE-user 403s and a `validation.test.js` `/api/public/track` 404) and untouched by this diff.
- [x] Manual sanity script: inserted a form/integration/submission, ran `enqueueAndAttempt` against an unreachable webhook URL, confirmed a `integration_deliveries` row is created with `status=retrying` and the SSRF-guard error recorded.
- [x] Manual sanity script: ran `startBackupScheduler` against a scratch DB/dir, confirmed a backup file is written and `listScheduledBackups` picks it up.
- [ ] Manual click-through of the new Integrations tab banner + "Retry now" button in a running dev server (not exercised in this session — recommend a quick smoke test before merging).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_012oHA3Ht3zPUgsvZxK73pFY

---
_Generated by [Claude Code](https://claude.ai/code/session_012oHA3Ht3zPUgsvZxK73pFY)_