### PR TITLE
Add Google Ads server-side conversion tracking integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.19.0] - 2026-07-14
+
+### Added
+- **Google Ads (Server-Side Conversion) integration** — a new integration type uploads qualifying leads as offline conversions to Google Ads via the [Data Manager API](https://developers.google.com/data-manager/api), Google's OAuth2-only successor to the legacy per-click conversion upload API. OpenFlow now captures `gclid`/`gbraid`/`wbraid` from a form's landing URL (gated behind the same cookie-consent setting already used for GTM) and stores it on the submission; a submission without a captured click ID is skipped by this integration rather than uploaded. Configured with a manually-pasted OAuth client ID/secret/refresh token, Google Ads customer ID, and conversion action ID — no developer token required. The integration's "Test" button validates the OAuth credentials only, since a synthetic test submission has no real click ID to upload.
+
 ## [0.18.0] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.18.0
+# 🌊 OpenFlow v0.19.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents
@@ -33,6 +33,7 @@
 - **📧 Email Notifications** — SMTP-based alerts with beautiful HTML submission tables
 - **📝 Google Sheets (Simple)** — Via Google Apps Script — no service account needed, just paste a URL
 - **📝 Google Sheets (Service Account)** — Auto-append rows via service account for advanced setups
+- **🎯 Google Ads (Server-Side Conversion)** — Upload leads with a captured `gclid`/`gbraid`/`wbraid` as offline conversions via Google's Data Manager API
 - **CSV Export** — Download all submissions as CSV
 - **Test Button** — Verify each integration with sample data before going live
 
@@ -194,6 +195,25 @@ Auto-append submissions via Google Apps Script — **no JSON key needed**.
 Auto-append each submission using a Google Service Account.
 - Auto-creates header row from form field labels
 - Configurable sheet name
+
+### 🎯 Google Ads (Server-Side Conversion)
+Upload qualifying leads as offline conversions directly to Google Ads, via the
+[Data Manager API](https://developers.google.com/data-manager/api) — no
+browser-side conversion pixel required.
+- OpenFlow captures `gclid`/`gbraid`/`wbraid` from the form's landing URL
+  (subject to the same cookie-consent setting used for GTM); submissions
+  without one of these click IDs are skipped, since there's nothing to
+  attribute them to
+- Requires a one-time setup outside OpenFlow: an OAuth client + refresh token
+  for a Google account with access to your Google Ads account (client ID,
+  client secret, refresh token, customer ID, conversion action ID — pasted
+  into the integration config, same as the Google Sheets service-account flow)
+- No developer token needed — the Data Manager API uses plain OAuth2
+- Optionally map one of the form's fields as the conversion value, or set a
+  fixed default value
+- The **Test** button only validates the OAuth credentials — it does not
+  upload a real conversion, since a test submission has no genuine click ID
+- See [`docs/integrations/google-ads.md`](docs/integrations/google-ads.md) for the full one-time setup walkthrough
 
 > 💡 Each integration has an **Enable/Disable** toggle and a **Test** button to verify your setup with sample data.
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.17.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.17.1",
+      "version": "0.19.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/models/deliveryQueue.js
+++ b/backend/src/models/deliveryQueue.js
@@ -16,7 +16,7 @@ function inMinutes(n) {
 // immediately, so the common (success) case has no added latency. Failures
 // are persisted with a next_attempt_at so the background worker retries
 // them instead of losing the submission.
-async function enqueueAndAttempt(db, formId, formTitle, submissionId, data, steps) {
+async function enqueueAndAttempt(db, formId, formTitle, submissionId, data, steps, metadata = {}) {
   const integrations = db.prepare(
     'SELECT * FROM integrations WHERE form_id = ? AND enabled = 1'
   ).all(formId);
@@ -28,13 +28,13 @@ async function enqueueAndAttempt(db, formId, formTitle, submissionId, data, step
        VALUES (?, ?, ?, ?, ?, 'pending')`
     ).run(deliveryId, formId, integration.id, submissionId, integration.type);
 
-    await attemptDelivery(db, { id: deliveryId, integration, formId, formTitle, data, steps });
+    await attemptDelivery(db, { id: deliveryId, integration, formId, formTitle, data, steps, metadata });
   }
 }
 
-async function attemptDelivery(db, { id, integration, formId, formTitle, data, steps }) {
+async function attemptDelivery(db, { id, integration, formId, formTitle, data, steps, metadata = {} }) {
   try {
-    await runIntegration(integration, formId, formTitle, data, steps);
+    await runIntegration(integration, formId, formTitle, data, steps, metadata);
     db.prepare(
       `UPDATE integration_deliveries SET status = 'success', updated_at = datetime('now') WHERE id = ?`
     ).run(id);
@@ -64,7 +64,7 @@ async function attemptDelivery(db, { id, integration, formId, formTitle, data, s
 // restarts (the queue only lives in SQLite, not in memory).
 async function processDueDeliveries(db) {
   const due = db.prepare(
-    `SELECT d.*, s.data AS submission_data, f.title AS form_title, f.steps AS form_steps
+    `SELECT d.*, s.data AS submission_data, s.metadata AS submission_metadata, f.title AS form_title, f.steps AS form_steps
      FROM integration_deliveries d
      JOIN submissions s ON s.id = d.submission_id
      JOIN forms f ON f.id = d.form_id
@@ -86,6 +86,7 @@ async function processDueDeliveries(db) {
       formTitle: row.form_title,
       data: JSON.parse(row.submission_data),
       steps: JSON.parse(row.form_steps),
+      metadata: JSON.parse(row.submission_metadata || '{}'),
     });
   }
 }
@@ -94,7 +95,7 @@ async function processDueDeliveries(db) {
 // fixes their webhook endpoint.
 async function retryDelivery(db, deliveryId) {
   const row = db.prepare(
-    `SELECT d.*, s.data AS submission_data, f.title AS form_title, f.steps AS form_steps
+    `SELECT d.*, s.data AS submission_data, s.metadata AS submission_metadata, f.title AS form_title, f.steps AS form_steps
      FROM integration_deliveries d
      JOIN submissions s ON s.id = d.submission_id
      JOIN forms f ON f.id = d.form_id
@@ -112,6 +113,7 @@ async function retryDelivery(db, deliveryId) {
     formTitle: row.form_title,
     data: JSON.parse(row.submission_data),
     steps: JSON.parse(row.form_steps),
+    metadata: JSON.parse(row.submission_metadata || '{}'),
   });
   return db.prepare('SELECT * FROM integration_deliveries WHERE id = ?').get(deliveryId);
 }

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -10,7 +10,7 @@ const { assertSafeUrl } = require('../utils/ssrf');
 // Run a single integration against a submission. Throws on failure so
 // callers (immediate fire-and-forget, or the retrying delivery queue) can
 // each decide how to handle/record the error.
-async function runIntegration(integration, formId, formTitle, submissionData, steps) {
+async function runIntegration(integration, formId, formTitle, submissionData, steps, metadata = {}) {
   const config = JSON.parse(integration.config);
   switch (integration.type) {
     case 'webhook':
@@ -22,12 +22,14 @@ async function runIntegration(integration, formId, formTitle, submissionData, st
         return runGoogleSheetsAppsScript(config, formId, formTitle, submissionData, steps);
       }
       return runGoogleSheets(config, formId, submissionData, steps);
+    case 'google_ads_conversion':
+      return runGoogleAdsConversion(config, submissionData, metadata);
     default:
       throw new Error(`Unknown integration type: ${integration.type}`);
   }
 }
 
-async function runIntegrations(db, formId, formTitle, submissionData, steps) {
+async function runIntegrations(db, formId, formTitle, submissionData, steps, metadata = {}) {
   const integrations = db.prepare(
     'SELECT * FROM integrations WHERE form_id = ? AND enabled = 1'
   ).all(formId);
@@ -35,7 +37,7 @@ async function runIntegrations(db, formId, formTitle, submissionData, steps) {
   const results = [];
   for (const integration of integrations) {
     try {
-      await runIntegration(integration, formId, formTitle, submissionData, steps);
+      await runIntegration(integration, formId, formTitle, submissionData, steps, metadata);
       results.push({ id: integration.id, type: integration.type, ok: true });
     } catch (err) {
       console.error(`Integration ${integration.type}/${integration.id} failed:`, err.message);
@@ -241,4 +243,93 @@ async function runGoogleSheets(config, formId, data, steps) {
   });
 }
 
-module.exports = { runIntegrations, runIntegration };
+// ──────────────────────────────────────────
+// Google Ads (server-side conversion upload via the Data Manager API)
+// ──────────────────────────────────────────
+
+// Exchanges the pasted long-lived refresh token for a short-lived OAuth
+// access token. Reuses the googleapis dependency already installed for the
+// Google Sheets service-account integration rather than hand-rolling the
+// OAuth2 refresh-token grant.
+async function getGoogleAdsAccessToken(config) {
+  const { client_id, client_secret, refresh_token } = config;
+  if (!client_id || !client_secret || !refresh_token) {
+    throw new Error('Google Ads client ID, client secret and refresh token are required');
+  }
+  const oauth2Client = new google.auth.OAuth2(client_id, client_secret);
+  oauth2Client.setCredentials({ refresh_token });
+  const { token } = await oauth2Client.getAccessToken();
+  if (!token) throw new Error('Failed to obtain a Google Ads access token from the refresh token');
+  return token;
+}
+
+async function runGoogleAdsConversion(config, data, metadata) {
+  const { customer_id, login_customer_id, conversion_action_id, currency_code = 'USD', default_value, value_field_id } = config;
+  if (!customer_id || !conversion_action_id) {
+    throw new Error('Google Ads customer ID and conversion action ID are required');
+  }
+
+  const gclid = metadata?.gclid;
+  const gbraid = metadata?.gbraid;
+  const wbraid = metadata?.wbraid;
+  if (!gclid && !gbraid && !wbraid) {
+    throw new Error('No Google Ads click ID (gclid/gbraid/wbraid) was captured for this submission');
+  }
+
+  const accessToken = await getGoogleAdsAccessToken(config);
+
+  let conversionValue = default_value !== undefined ? Number(default_value) : undefined;
+  if (value_field_id) {
+    const raw = data[value_field_id];
+    const parsed = Number(raw);
+    if (raw !== undefined && !Number.isNaN(parsed)) conversionValue = parsed;
+  }
+
+  const adIdentifiers = {};
+  if (gclid) adIdentifiers.gclid = gclid;
+  if (gbraid) adIdentifiers.gbraid = gbraid;
+  if (wbraid) adIdentifiers.wbraid = wbraid;
+
+  const destination = {
+    reference: 'd1',
+    operatingAccount: { accountId: String(customer_id).replace(/-/g, ''), accountType: 'GOOGLE_ADS' },
+    productDestinationId: String(conversion_action_id),
+  };
+  if (login_customer_id) {
+    destination.loginAccount = { accountId: String(login_customer_id).replace(/-/g, ''), accountType: 'GOOGLE_ADS' };
+  }
+
+  const event = {
+    destinationReferences: ['d1'],
+    transactionId: `${gclid || gbraid || wbraid}:${metadata?.submittedAt || new Date().toISOString()}`,
+    eventTimestamp: metadata?.submittedAt || new Date().toISOString(),
+    eventSource: 'WEB',
+    adIdentifiers,
+  };
+  if (conversionValue !== undefined) event.conversionValue = conversionValue;
+  if (currency_code) event.currency = currency_code;
+
+  const res = await fetch('https://datamanager.googleapis.com/v1/events:ingest', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ destinations: [destination], events: [event] }),
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Google Ads Data Manager API returned ${res.status}: ${await res.text().catch(() => '')}`);
+  }
+}
+
+// Validates Google Ads credentials without uploading a conversion — used by
+// the integration "Test" button, since a synthetic test submission has no
+// real gclid and would either fail or (worse) upload garbage to a real
+// Google Ads account.
+async function testGoogleAdsCredentials(config) {
+  await getGoogleAdsAccessToken(config);
+}
+
+module.exports = { runIntegrations, runIntegration, testGoogleAdsCredentials };

--- a/backend/src/routes/integrations.js
+++ b/backend/src/routes/integrations.js
@@ -26,8 +26,8 @@ router.post('/:formId', (req, res) => {
   if (!form) return res.status(404).json({ error: 'Form not found' });
 
   const { type, config, enabled } = req.body;
-  if (!type || !['webhook', 'email', 'google_sheets'].includes(type)) {
-    return res.status(400).json({ error: 'Invalid integration type. Use: webhook, email, google_sheets' });
+  if (!type || !['webhook', 'email', 'google_sheets', 'google_ads_conversion'].includes(type)) {
+    return res.status(400).json({ error: 'Invalid integration type. Use: webhook, email, google_sheets, google_ads_conversion' });
   }
 
   const id = uuid();
@@ -85,7 +85,19 @@ router.post('/:formId/:integrationId/test', async (req, res) => {
   const testData = {};
   steps.forEach(s => { testData[s.id] = `Test value for ${s.label || s.id}`; });
 
-  const { runIntegrations } = require('../models/integrations');
+  const { runIntegrations, testGoogleAdsCredentials } = require('../models/integrations');
+
+  // A synthetic test submission has no real gclid, so actually running this
+  // integration would either fail outright or upload a fake conversion to a
+  // real Google Ads account. Instead, just verify the OAuth credentials work.
+  if (integration.type === 'google_ads_conversion') {
+    try {
+      await testGoogleAdsCredentials(JSON.parse(integration.config));
+      return res.json({ results: [{ id: integration.id, type: integration.type, ok: true }] });
+    } catch (err) {
+      return res.json({ results: [{ id: integration.id, type: integration.type, ok: false, error: err.message }] });
+    }
+  }
 
   try {
     // Run just this one integration

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -98,6 +98,16 @@ router.post('/form/:slug/submit', async (req, res) => {
     submittedAt: new Date().toISOString(),
   };
 
+  // Whitelist the ad click IDs the client may have captured from the
+  // landing URL (see FormView/EmbedView) — don't spread arbitrary
+  // client-supplied JSON into stored metadata.
+  const tracking = req.body.tracking;
+  if (tracking && typeof tracking === 'object') {
+    ['gclid', 'gbraid', 'wbraid'].forEach(key => {
+      if (typeof tracking[key] === 'string' && tracking[key]) metadata[key] = tracking[key];
+    });
+  }
+
   db.prepare('INSERT INTO submissions (id, form_id, data, metadata) VALUES (?, ?, ?, ?)').run(
     id, form.id, JSON.stringify(data), JSON.stringify(metadata)
   );
@@ -108,7 +118,7 @@ router.post('/form/:slug/submit', async (req, res) => {
   // persisted first, so a failure (client webhook down, SMTP hiccup) retries
   // with backoff instead of silently losing the lead.
   const { enqueueAndAttempt } = require('../models/deliveryQueue');
-  enqueueAndAttempt(db, form.id, form.title, id, data, steps).catch(err => {
+  enqueueAndAttempt(db, form.id, form.title, id, data, steps, metadata).catch(err => {
     console.error('Integration delivery error:', err.message);
   });
 });

--- a/docs/integrations/google-ads.md
+++ b/docs/integrations/google-ads.md
@@ -1,0 +1,84 @@
+# Google Ads (Server-Side Conversion) Setup
+
+This integration uploads qualifying leads as offline conversions to Google
+Ads via Google's [Data Manager API](https://developers.google.com/data-manager/api),
+using the `gclid`/`gbraid`/`wbraid` click ID captured from the form's landing
+URL. It does not require a Google Ads developer token — only a standard
+OAuth2 client and a refresh token for a Google account with access to the
+target Google Ads account.
+
+This is a one-time setup you do outside OpenFlow, in the Google Cloud
+Console and Google Ads UI. OpenFlow itself only stores the resulting
+credentials (pasted into the integration config) — it does not perform an
+OAuth consent flow on your behalf.
+
+## 1. Create a Google Cloud project and OAuth client
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/) and
+   create (or reuse) a project.
+2. Under **APIs & Services → Library**, enable the **Data Manager API**.
+3. Under **APIs & Services → Credentials**, create an **OAuth client ID**.
+   Choose **Desktop app** as the application type — this avoids needing a
+   public redirect URI, and is sufficient for the one-time token exchange
+   below.
+4. Note the **Client ID** and **Client Secret**.
+
+## 2. Generate a refresh token
+
+Using the OAuth client from step 1, run through a one-time OAuth consent
+flow to obtain a refresh token for a Google account that has access to your
+Google Ads account. Two common ways to do this:
+
+- **Google OAuth 2.0 Playground** (https://developers.google.com/oauthplayground):
+  in the gear icon settings, check "Use your own OAuth credentials" and
+  paste in your client ID/secret, then authorize scope
+  `https://www.googleapis.com/auth/datamanager` and exchange the
+  authorization code for tokens. Copy the **refresh token** from the result.
+- A small local script using any OAuth2 library (e.g. Google's official
+  client libraries) performing the standard installed-app authorization
+  code flow with the same scope.
+
+Keep this refresh token secret — it's a long-lived credential.
+
+## 3. Find your Google Ads customer ID and conversion action ID
+
+1. **Customer ID**: shown in the top-right of the Google Ads UI when signed
+   into the target account, formatted like `123-456-7890`. If the account
+   sits under a manager (MCC) account, also note the manager account's
+   customer ID — you'll enter that as the optional "Login Customer ID".
+2. **Conversion Action ID**: in Google Ads, go to **Goals → Conversions**,
+   open (or create) a conversion action of type "Import" / click-based
+   upload, and note its ID (visible in the URL or via the Google Ads API/UI
+   details for that conversion action).
+
+## 4. Configure the integration in OpenFlow
+
+In the form's **Integrations** tab, add a **Google Ads (Server-Side
+Conversion)** integration and fill in:
+
+| Field | Value |
+|-------|-------|
+| OAuth Client ID | From step 1 |
+| OAuth Client Secret | From step 1 |
+| Refresh Token | From step 2 |
+| Customer ID | From step 3 |
+| Login Customer ID | Only if under a manager/MCC account |
+| Conversion Action ID | From step 3 |
+| Currency | e.g. `USD` |
+| Default Value / Value Field | A fixed conversion value, or map one of the form's numeric fields |
+
+Click **Test** to verify the credentials (this does not upload a real
+conversion — a test submission has no genuine click ID).
+
+## How it works
+
+- OpenFlow captures `gclid`/`gbraid`/`wbraid` from the form's URL query
+  string when the visitor lands on it, subject to the same cookie-consent
+  setting already used for Google Tag Manager.
+- A submission that arrives **without** one of these click IDs (i.e. an
+  organic/direct visitor, not someone who clicked a Google ad) is skipped by
+  this integration — there's nothing to attribute it to.
+- Uploads happen asynchronously after the submission is stored, with the
+  same retry/dead-letter handling as OpenFlow's other integrations; a
+  failed upload can be inspected and manually retried from the Integrations
+  tab.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -82,5 +82,5 @@ export const api = {
   restoreBackup: (backup) => request('/admin/restore', { method: 'POST', body: JSON.stringify(backup) }),
 
   getPublicForm: (slug) => request(`/public/form/${slug}`),
-  submitForm: (slug, data) => request(`/public/form/${slug}/submit`, { method: 'POST', body: JSON.stringify({ data }) }),
+  submitForm: (slug, data, tracking) => request(`/public/form/${slug}/submit`, { method: 'POST', body: JSON.stringify({ data, tracking }) }),
 };

--- a/frontend/src/components/IntegrationsPanel.jsx
+++ b/frontend/src/components/IntegrationsPanel.jsx
@@ -1,14 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { api } from '../api';
+import { flattenFields } from '../utils/steps';
 
 const INTEGRATION_TYPES = [
   { value: 'webhook', label: 'Webhook', icon: '🔗', description: 'Send submission data to any URL' },
   { value: 'email', label: 'Email Notification', icon: '📧', description: 'Send email on each submission' },
   { value: 'google_sheets', label: 'Google Sheets (Simple)', icon: '📊', description: 'Via Google Apps Script — no JSON key needed' },
   { value: 'google_sheets_sa', label: 'Google Sheets (Service Account)', icon: '📊', description: 'Via service account JSON key' },
+  { value: 'google_ads_conversion', label: 'Google Ads (Server-Side Conversion)', icon: '🎯', description: 'Upload leads as offline conversions via the Data Manager API' },
 ];
 
-export default function IntegrationsPanel({ formId }) {
+export default function IntegrationsPanel({ formId, steps = [] }) {
   const [integrations, setIntegrations] = useState([]);
   const [adding, setAdding] = useState(null);
   const [testing, setTesting] = useState(null);
@@ -60,6 +62,11 @@ export default function IntegrationsPanel({ formId }) {
       email: { smtp_host: '', smtp_port: 587, smtp_user: '', smtp_pass: '', smtp_secure: false, to: '', from: '', subject: '', lodgely_link_enabled: false, lodgely_url: '', lodgely_button_text: '' },
       google_sheets: { mode: 'apps_script', apps_script_url: '' },
       google_sheets_sa: { mode: 'service_account', credentials_json: '', spreadsheet_id: '', sheet_name: 'Sheet1' },
+      google_ads_conversion: {
+        client_id: '', client_secret: '', refresh_token: '',
+        customer_id: '', login_customer_id: '', conversion_action_id: '',
+        currency_code: 'USD', default_value: '', value_field_id: '',
+      },
     };
     try {
       const { integration } = await api.createIntegration(formId, { type: actualType, config: defaults[type] || defaults[actualType] });
@@ -230,6 +237,9 @@ export default function IntegrationsPanel({ formId }) {
           {integration.type === 'google_sheets' && (
             <GoogleSheetsConfig config={integration.config} onChange={(k, v) => updateConfig(integration.id, k, v)} />
           )}
+          {integration.type === 'google_ads_conversion' && (
+            <GoogleAdsConfig config={integration.config} steps={steps} onChange={(k, v) => updateConfig(integration.id, k, v)} />
+          )}
         </div>
       ))}
     </div>
@@ -392,6 +402,64 @@ function GoogleSheetsConfig({ config, onChange }) {
         <p style={{ fontSize: 12, color: '#636E72', marginTop: 4 }}>
           Create a service account in Google Cloud Console, download the JSON key, and share the spreadsheet with the service account email.
         </p>
+      </div>
+    </div>
+  );
+}
+
+function GoogleAdsConfig({ config, steps, onChange }) {
+  const fields = flattenFields(steps);
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+      <div style={{ gridColumn: '1 / -1', background: '#F0F4FF', borderRadius: 8, padding: 16, fontSize: 13, lineHeight: 1.7 }}>
+        Requires a one-time setup outside OpenFlow: create an OAuth client in
+        Google Cloud Console, enable the Data Manager API, and generate a
+        refresh token for a user with access to your Google Ads account. Only
+        submissions that arrive with a captured <code>gclid</code>/<code>gbraid</code>/<code>wbraid</code> (i.e.
+        the visitor came from a Google Ads click) are uploaded — organic
+        submissions are skipped.
+      </div>
+      <div className="input-group">
+        <label>OAuth Client ID</label>
+        <input className="input" value={config.client_id || ''} onChange={e => onChange('client_id', e.target.value)} />
+      </div>
+      <div className="input-group">
+        <label>OAuth Client Secret</label>
+        <input className="input" type="password" value={config.client_secret || ''} onChange={e => onChange('client_secret', e.target.value)} />
+      </div>
+      <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+        <label>Refresh Token</label>
+        <input className="input" type="password" value={config.refresh_token || ''} onChange={e => onChange('refresh_token', e.target.value)} />
+      </div>
+      <div className="input-group">
+        <label>Customer ID</label>
+        <input className="input" value={config.customer_id || ''} onChange={e => onChange('customer_id', e.target.value)} placeholder="123-456-7890" />
+      </div>
+      <div className="input-group">
+        <label>Login Customer ID (optional)</label>
+        <input className="input" value={config.login_customer_id || ''} onChange={e => onChange('login_customer_id', e.target.value)} placeholder="Only if under a manager (MCC) account" />
+      </div>
+      <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+        <label>Conversion Action ID</label>
+        <input className="input" value={config.conversion_action_id || ''} onChange={e => onChange('conversion_action_id', e.target.value)} />
+      </div>
+      <div className="input-group">
+        <label>Currency</label>
+        <input className="input" value={config.currency_code || 'USD'} onChange={e => onChange('currency_code', e.target.value)} placeholder="USD" />
+      </div>
+      <div className="input-group">
+        <label>Default Value (optional)</label>
+        <input className="input" type="number" value={config.default_value ?? ''} onChange={e => onChange('default_value', e.target.value)} placeholder="e.g. 100" />
+      </div>
+      <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+        <label>Value Field (optional — overrides default value when answered)</label>
+        <select className="input" value={config.value_field_id || ''} onChange={e => onChange('value_field_id', e.target.value)}>
+          <option value="">None — use default value</option>
+          {fields.map(f => (
+            <option key={f.id} value={f.id}>{f.label || f.question || f.id}</option>
+          ))}
+        </select>
       </div>
     </div>
   );

--- a/frontend/src/pages/EmbedView.jsx
+++ b/frontend/src/pages/EmbedView.jsx
@@ -49,6 +49,7 @@ export default function EmbedView() {
   const [form, setForm] = useState(null);
   const [error, setError] = useState('');
   const [cookieConsent, setCookieConsent] = useState(null);
+  const [clickIds, setClickIds] = useState({});
 
   // Force light theme on embedded form pages (dark mode is admin-only)
   useEffect(() => {
@@ -73,16 +74,31 @@ export default function EmbedView() {
       .catch(e => setError(e.message));
   }, [slug, navigate]);
 
-  // Determine cookie consent state once form is loaded
+  // Determine cookie consent state once form is loaded. This gates both GTM
+  // injection and ad click-ID capture (gclid/gbraid/wbraid), so it no longer
+  // short-circuits on gtm_id alone.
   useEffect(() => {
     if (!form) return;
-    if (!form.gtm_id) { setCookieConsent(null); return; }
     if (!form.end_screen?.cookieConsentEnabled) { setCookieConsent(true); return; }
     const stored = localStorage.getItem(`of_cc_${form.id}`);
     if (stored === 'accepted') { setCookieConsent(true); }
     else if (stored === 'declined') { setCookieConsent(false); }
     else { setCookieConsent('pending'); }
   }, [form]);
+
+  // Capture Google Ads click IDs from the landing URL, once consent allows
+  // it, so they can ride along with the submission for server-side
+  // conversion upload.
+  useEffect(() => {
+    if (cookieConsent !== true) return;
+    const params = new URLSearchParams(window.location.search);
+    const ids = {};
+    ['gclid', 'gbraid', 'wbraid'].forEach(key => {
+      const value = params.get(key);
+      if (value) ids[key] = value;
+    });
+    if (Object.keys(ids).length) setClickIds(ids);
+  }, [cookieConsent]);
 
   // Inject GTM only when consent is given
   useEffect(() => {
@@ -126,7 +142,7 @@ export default function EmbedView() {
 
   return (
     <>
-      <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data)} embedded />
+      <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data, clickIds)} embedded />
       {cookieConsent === 'pending' && (
         <CookieBanner form={form} onAccept={handleAccept} onDecline={handleDecline} />
       )}

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -724,7 +724,7 @@ export default function FormEditor() {
 
       {/* Integrations Tab */}
       {activeTab === 'integrations' && (
-        <IntegrationsPanel formId={id} />
+        <IntegrationsPanel formId={id} steps={form.steps} />
       )}
 
       {/* Embed Tab */}

--- a/frontend/src/pages/FormView.jsx
+++ b/frontend/src/pages/FormView.jsx
@@ -51,6 +51,7 @@ export default function FormView({ slugProp, hostMode = false }) {
   const [error, setError] = useState('');
   // null = not yet determined, true = accepted, false = declined, 'pending' = needs banner
   const [cookieConsent, setCookieConsent] = useState(null);
+  const [clickIds, setClickIds] = useState({});
 
   // Force light theme on public form pages (dark mode is admin-only)
   useEffect(() => {
@@ -77,16 +78,31 @@ export default function FormView({ slugProp, hostMode = false }) {
       .catch(e => setError(e.message));
   }, [slug, navigate, hostMode]);
 
-  // Determine cookie consent state once form is loaded
+  // Determine cookie consent state once form is loaded. This gates both GTM
+  // injection and ad click-ID capture (gclid/gbraid/wbraid), so it no longer
+  // short-circuits on gtm_id alone.
   useEffect(() => {
     if (!form) return;
-    if (!form.gtm_id) { setCookieConsent(null); return; }
     if (!form.end_screen?.cookieConsentEnabled) { setCookieConsent(true); return; }
     const stored = localStorage.getItem(`of_cc_${form.id}`);
     if (stored === 'accepted') { setCookieConsent(true); }
     else if (stored === 'declined') { setCookieConsent(false); }
     else { setCookieConsent('pending'); }
   }, [form]);
+
+  // Capture Google Ads click IDs from the landing URL, once consent allows
+  // it, so they can ride along with the submission for server-side
+  // conversion upload.
+  useEffect(() => {
+    if (cookieConsent !== true) return;
+    const params = new URLSearchParams(window.location.search);
+    const ids = {};
+    ['gclid', 'gbraid', 'wbraid'].forEach(key => {
+      const value = params.get(key);
+      if (value) ids[key] = value;
+    });
+    if (Object.keys(ids).length) setClickIds(ids);
+  }, [cookieConsent]);
 
   // Inject GTM only when consent is given
   useEffect(() => {
@@ -118,7 +134,7 @@ export default function FormView({ slugProp, hostMode = false }) {
 
   return (
     <>
-      <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data)} />
+      <FormRenderer form={form} onSubmit={(data) => api.submitForm(slug, data, clickIds)} />
       {cookieConsent === 'pending' && (
         <CookieBanner form={form} onAccept={handleAccept} onDecline={handleDecline} />
       )}


### PR DESCRIPTION
## Summary

- Adds a new **Google Ads (Server-Side Conversion)** integration type that uploads qualifying leads as offline conversions to Google Ads via the [Data Manager API](https://developers.google.com/data-manager/api) — Google's OAuth2-only successor to the legacy per-click conversion upload API (which is closed to new adopters as of mid-2026). No developer token required.
- `FormView`/`EmbedView` now capture `gclid`/`gbraid`/`wbraid` from the form's landing URL, gated behind the same cookie-consent setting already used for GTM, and pass them through to the submission. A submission without a captured click ID is skipped by this integration (there's nothing to attribute it to).
- Credentials (OAuth client ID/secret, refresh token, customer ID, conversion action ID) are pasted into the integration config, mirroring the existing Google Sheets service-account UX — appropriate for OpenFlow's self-hosted, per-install deployment model where a shared in-app OAuth "Connect" flow isn't practical.
- The integration's **Test** button validates the OAuth credentials only (exchanges the refresh token for an access token) rather than uploading a real conversion, since a synthetic test submission has no genuine click ID.
- Threaded a new `metadata` parameter through the existing delivery/retry pipeline (`runIntegration`, `enqueueAndAttempt`, `attemptDelivery`, `processDueDeliveries`, `retryDelivery`) so the captured click ID reaches the handler even on a retried delivery after a process restart.
- Added `docs/integrations/google-ads.md` with the one-time Google Cloud/Ads setup walkthrough, linked from the README.
- Version bump to 0.19.0 per repo convention (README badge, CHANGELOG, both `package.json`).

## Test plan

- [x] `cd backend && npx jest --ci --runInBand --forceExit` — 109/114 passing; the 5 failures (`auth.test.js` user-deletion tests, one `validation.test.js` analytics-event test) are pre-existing on `main` (verified via `git stash` + re-run against the unmodified base) and unrelated to this change.
- [ ] Manual end-to-end verification with real Google Ads OAuth credentials (not possible in this sandbox — no live Google Ads account/API access): create the integration, load a form URL with `?gclid=...` appended, submit, and confirm the delivery succeeds and the submission's stored `metadata` contains the click ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PKipuzt3Vwr6cm83ZaqBAJ)_