### PR TITLE
Fix integration delete FK error and Google Ads tip contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.19.1] - 2026-07-15
+
+### Fixed
+- **Deleting a webhook (or other integration) with delivery history failed** — `integration_deliveries` rows reference their integration via a foreign key, so deleting an integration that had already attempted at least one delivery violated the constraint and the API returned a non-JSON error page instead of a clean response. The delete route now clears the integration's delivery history first, in the same transaction.
+- **Google Ads integration setup tip was unreadable in dark mode** — the tip box didn't set an explicit text color, so it inherited the dark-mode near-white body text on its light background. It now uses an explicit dark text color regardless of theme.
+
 ## [0.19.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.19.0
+# 🌊 OpenFlow v0.19.1
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/routes/integrations.js
+++ b/backend/src/routes/integrations.js
@@ -68,7 +68,15 @@ router.delete('/:formId/:integrationId', (req, res) => {
   const form = db.prepare('SELECT id FROM forms WHERE id = ? AND user_id = ?').get(req.params.formId, req.userId);
   if (!form) return res.status(404).json({ error: 'Form not found' });
 
-  db.prepare('DELETE FROM integrations WHERE id = ? AND form_id = ?').run(req.params.integrationId, req.params.formId);
+  // integration_deliveries rows reference this integration via a foreign key
+  // (foreign_keys = ON), so an integration that has ever attempted a
+  // delivery must have its delivery history cleared first or the DELETE
+  // below throws a FOREIGN KEY constraint error.
+  const deleteIntegration = db.transaction(() => {
+    db.prepare('DELETE FROM integration_deliveries WHERE integration_id = ?').run(req.params.integrationId);
+    db.prepare('DELETE FROM integrations WHERE id = ? AND form_id = ?').run(req.params.integrationId, req.params.formId);
+  });
+  deleteIntegration();
   res.json({ ok: true });
 });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/IntegrationsPanel.jsx
+++ b/frontend/src/components/IntegrationsPanel.jsx
@@ -412,7 +412,7 @@ function GoogleAdsConfig({ config, steps, onChange }) {
 
   return (
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-      <div style={{ gridColumn: '1 / -1', background: '#F0F4FF', borderRadius: 8, padding: 16, fontSize: 13, lineHeight: 1.7 }}>
+      <div style={{ gridColumn: '1 / -1', background: '#F0F4FF', color: '#2D3436', borderRadius: 8, padding: 16, fontSize: 13, lineHeight: 1.7 }}>
         Requires a one-time setup outside OpenFlow: create an OAuth client in
         Google Cloud Console, enable the Data Manager API, and generate a
         refresh token for a user with access to your Google Ads account. Only


### PR DESCRIPTION
## Summary
- Fix `DELETE /api/integrations/:formId/:integrationId` failing with a foreign-key constraint error (surfaced to the frontend as an "Invalid JSON response" error) whenever the integration had at least one row in `integration_deliveries`. This affected any integration — most visibly webhooks — once a delivery had ever been attempted for it. The route now deletes the delivery history in the same transaction before deleting the integration.
- Fix the Google Ads (Server-Side Conversion) setup tip box rendering near-white text on its light background in dark mode, by giving it an explicit text color instead of inheriting the theme's `--text` variable.

## Test plan
- [x] `cd backend && npx jest --ci --runInBand --forceExit` — 109/114 pass; the 2 failing suites (`auth.test.js`, `validation.test.js`) fail identically on `main` (pre-existing, unrelated to this change).
- [x] Reproduced the delete bug and verified the fix in isolation: inserted an integration + a linked `integration_deliveries` row, confirmed the old single `DELETE` statement raises `SQLITE_CONSTRAINT_FOREIGNKEY`, confirmed the new transactional delete succeeds and removes both rows.
- [ ] Manual visual check of the Google Ads tip box in a browser under dark mode (not possible in this sandbox — no browser environment available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKipuzt3Vwr6cm83ZaqBAJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKipuzt3Vwr6cm83ZaqBAJ)_