### PR TITLE
Add Ctrl/Cmd+Enter shortcut to advance from long-text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.20.0] - 2026-07-15
+
+### Added
+- **Ctrl/Cmd+Enter to advance from long-text fields** — long-text (textarea) steps previously required clicking the Next/Submit button, since plain Enter needs to stay free for line breaks. They now also advance on Ctrl+Enter (Windows/Linux) or ⌘+Enter (Mac), matching the shortcut convention from chat and note-taking apps. The optional "Enter Key Hint" now shows the right shortcut per field type (`Enter ↵` for regular fields, `Ctrl + Enter` / `⌘ + Enter` for long-text fields).
+
 ## [0.19.1] - 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.19.1
+# 🌊 OpenFlow v0.20.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -266,10 +266,11 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   }
 
   function handleKeyDown(e) {
-    if (e.key === 'Enter' && step?.type !== 'textarea') {
-      e.preventDefault();
-      next();
-    }
+    if (e.key !== 'Enter') return;
+    // Textareas need plain Enter for newlines; only advance on Ctrl/Cmd+Enter.
+    if (step?.type === 'textarea' && !(e.metaKey || e.ctrlKey)) return;
+    e.preventDefault();
+    next();
   }
 
   // Track form view on mount
@@ -358,9 +359,13 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
   const footerLinks = (theme.footerLinks || []).filter(l => l.title && l.url);
 
-  const enterHint = showEnterHint && step?.type !== 'textarea' ? (
+  const isMacPlatform = typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/.test(navigator.platform || navigator.userAgent || '');
+  const enterKbdLabel = step?.type === 'textarea'
+    ? (isMacPlatform ? '⌘ + Enter' : 'Ctrl + Enter')
+    : 'Enter ↵';
+  const enterHint = showEnterHint ? (
     <span className="form-enter-hint">
-      {locale.enterHintBefore}<kbd>Enter &#8629;</kbd>{locale.enterHintAfter}
+      {locale.enterHintBefore}<kbd>{enterKbdLabel}</kbd>{locale.enterHintAfter}
     </span>
   ) : null;
 

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -468,7 +468,7 @@ export default function FormEditor() {
                   Show "press Enter" hint next to button
                 </label>
                 <span style={{ fontSize: 11, color: '#999', marginTop: 8, display: 'block' }}>
-                  Displays a subtle keyboard shortcut hint (press Enter &#8629;) next to the Next button.
+                  Displays a subtle keyboard shortcut hint next to the Next button (press Enter &#8629;, or Ctrl/&#8984; + Enter for long-text fields).
                 </span>
               </div>
               <div className="input-group">


### PR DESCRIPTION
## Summary
- Long-text (textarea) steps previously required clicking the Next/Submit button, since plain `Enter` needs to stay free for line breaks.
- `FormRenderer`'s keyboard handler now also advances the step on `Ctrl+Enter` (Windows/Linux) or `⌘+Enter` (Mac) when the current step is a textarea — the same convention used by chat and note-taking apps (Slack, Notion, etc.).
- The optional "Enter Key Hint" (form theme setting) now shows the correct shortcut per field type: `Enter ↵` for regular fields, `Ctrl + Enter` / `⌘ + Enter` for long-text fields, detected via `navigator.platform`.
- Bumped version to 0.20.0 per repo convention (README badge, CHANGELOG, both `package.json`s).

## Test plan
- [ ] Open a form with a long-text (textarea) field in the public form view; confirm plain `Enter` inserts a newline instead of advancing.
- [ ] Confirm `Ctrl+Enter` (or `⌘+Enter` on Mac) advances to the next step / submits from a textarea field.
- [ ] Confirm regular fields (text, email, select, etc.) still advance on plain `Enter` as before.
- [ ] Enable "Enter Key Hint" in the form theme editor and confirm the hint shows `Enter ↵` on normal fields and `Ctrl + Enter` / `⌘ + Enter` on textarea fields.


---
_Generated by [Claude Code](https://claude.ai/code/session_017orjq3W83P8jeDo4H2jWYs)_