### PR TITLE
Ignore scheduled backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 *.log
 .DS_Store
 backend/data/.jwt_secret
+# Scheduled backups contain submissions and password hashes — never commit them
+backend/data/backups/


### PR DESCRIPTION
Follow-up to #82 (already merged). One line in `.gitignore`.

## Problem

The scheduled backup writer drops JSON dumps in `backend/data/backups/`, but that directory was never ignored. I hit this while testing #82 — running the dev server for a few minutes produced two backup files that showed up as untracked.

The dumps are full table contents. Each one includes user emails and bcrypt password hashes:

```json
{"openflow_backup":true,"version":1,"app_version":"0.21.1","tables":{"users":[{"id":"…","email":"admin@openflow.local","password_hash":"$2a$10$…","role":"admin",…
```

…along with every submission in the database. Anyone who runs the server locally and stages everything commits real user data, and the `.db` files being ignored gives a false sense that the data directory is already covered.

## Fix

```
# Scheduled backups contain submissions and password hashes — never commit them
backend/data/backups/
```

Verified by dropping a file into the directory and confirming `git status --untracked=all` no longer reports it.

No functional change — the backup feature still writes exactly where it did before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA9UBECYUTS4r1Pn2QdDkz)_