### PR TITLE
Keep the Enter-key hint visible in small iframe embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.21.2] - 2026-08-04
+
+### Fixed
+- **The "press Enter" hint disappeared in small embeds** — the hint was hidden by a `max-width: 600px` media query. Inside an iframe such a query resolves against the iframe's own width, not the device's, so any narrow embed dropped the hint on desktop, where the Enter key does work. Hiding is now keyed off `(hover: none) and (pointer: coarse)`, which targets touch devices without a physical keyboard regardless of the frame's size; in narrow frames the hint just renders slightly smaller.
+- **Footer and button rows could overflow in narrow embeds** — the navigation footer and the inline/below-input button rows now wrap instead of pushing the Next button and the Enter hint out of the visible area.
+
 ## [0.21.1] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.21.1
+# 🌊 OpenFlow v0.21.2
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.css
+++ b/frontend/src/components/FormRenderer.css
@@ -336,10 +336,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
   padding: 16px 24px;
   background: var(--form-bg, rgba(255, 255, 255, 0.9));
   border-top: 1px solid rgba(var(--form-text-rgb, 45, 52, 54), 0.06);
   flex-shrink: 0;
+}
+
+/* Right-hand side of the footer: enter hint + next button */
+.form-nav-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .form-nav-btn {
@@ -543,6 +554,7 @@
 .form-inline-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 16px;
   margin-top: 32px;
 }
@@ -551,6 +563,7 @@
 .form-below-input-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 16px;
   margin-top: 24px;
 }
@@ -562,6 +575,17 @@
   font-size: 13px;
   color: rgba(var(--form-text-rgb, 45, 52, 54), 0.35);
   font-weight: 500;
+  white-space: nowrap;
+}
+
+/* Touch devices have no physical keyboard, so the hint is useless there.
+   Keyed off pointer/hover, never viewport width: a media query inside an
+   iframe resolves against the iframe's own width, so a width rule would
+   also hide the hint in small desktop embeds where Enter does work. */
+@media (hover: none) and (pointer: coarse) {
+  .form-enter-hint {
+    display: none;
+  }
 }
 
 .form-enter-hint kbd {
@@ -882,6 +906,10 @@
   }
 
   .form-enter-hint {
-    display: none;
+    font-size: 12px;
+  }
+
+  .form-enter-hint kbd {
+    padding: 2px 6px;
   }
 }

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -500,7 +500,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
           &#8592;
         </button>
         <span className="form-step-count">{currentStep + 1} / {steps.length}</span>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div className="form-nav-actions">
           {buttonPosition === 'footer' && enterHint}
           {buttonPosition === 'footer' && nextButton}
           {(buttonPosition === 'inline' || buttonPosition === 'below-input') && <span />}


### PR DESCRIPTION
## Problem

When a form is embedded as a narrow iframe, the optional "press Enter" hint next to the Next button disappears — even on desktop, where the Enter key works fine.

The hint was hidden by the mobile block in `FormRenderer.css`:

```css
@media (max-width: 600px) {
  .form-enter-hint { display: none; }
}
```

Inside an iframe, a width media query resolves against the **iframe's own viewport**, not the device screen. So any embed narrower than 600px matched the "mobile" rule and dropped the hint, regardless of whether the visitor had a keyboard.

## Fix

- Hiding is now keyed off `@media (hover: none) and (pointer: coarse)` — interaction media features come from the actual input device, so they stay correct inside an iframe of any size. Touch devices (no physical keyboard) still don't see the hint; small desktop embeds do.
- In narrow frames the hint renders slightly smaller (`font-size: 12px`, tighter `kbd` padding) instead of vanishing, and gets `white-space: nowrap` so it never breaks mid-label.
- `.form-nav`, `.form-inline-actions` and `.form-below-input-actions` now `flex-wrap`, so in a very small frame the hint and the Next button wrap onto their own line rather than overflowing. The footer's action group moved from an inline style to a `.form-nav-actions` class for this.

## Verification

`npm run build` in `frontend/` passes. The change is CSS-only plus a one-line class swap in `FormRenderer.jsx`; no renderer logic, keyboard handling or API shape is touched.

## Version

Bumped to **0.21.2** (patch) across `README.md`, `CHANGELOG.md`, `backend/package.json` and `frontend/package.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNZtYhdFxhZ5DoJ5JnGj2X)_