### PR TITLE
Hide the Enter hint on click-only choice steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.21.3] - 2026-08-04
+
+### Fixed
+- **The "press Enter" hint showed on click-only choice steps** — single choice, multiple choice, yes/no, rating and image select are answered by clicking an option, and the click already advances the step, so telling the visitor to press Enter was meaningless. The hint is now suppressed on any step that advances on the click itself. It still appears on choice steps that genuinely wait for the button — when **auto-advance is disabled** in the theme, or on a multiple-choice step with an "Other" free-text box — since Enter is the shortcut to continue there.
+- **Enter on a focused option button skipped the step instead of selecting** — the renderer's Enter handler ran on the bubbled keypress and called `preventDefault()`, which swallowed the button's own activation. Keyboard visitors tabbing through the options jumped forward without their answer being recorded. Enter aimed at a button or link now activates that element and is left alone.
+
 ## [0.21.2] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.21.2
+# 🌊 OpenFlow v0.21.3
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -281,6 +281,10 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
   function handleKeyDown(e) {
     if (e.key !== 'Enter') return;
+    // Enter on a focused button or link has to activate that element — a choice
+    // option, the Next button, a footer link. Advancing here instead would eat
+    // the keystroke and skip the step without recording the answer.
+    if (e.target.closest?.('button, a')) return;
     // Textareas need plain Enter for newlines; only advance on Ctrl/Cmd+Enter.
     if (step?.type === 'textarea' && !(e.metaKey || e.ctrlKey)) return;
     e.preventDefault();
@@ -318,11 +322,14 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   const autoAdvances = step && AUTO_ADVANCE_FIELDS.includes(step.type)
     && !(step.type === 'multi-select' && step.allowOther);
 
+  // Whether picking an option is all the visitor has to do on this step.
+  const advancesOnClick = autoAdvances && !theme?.disableAutoAdvance;
+
   // Auto-advance for choice-based field types when answer is provided.
   // Capture the step index at schedule time and compare against the ref at
   // fire time so we don't advance if the user has already navigated away.
   useEffect(() => {
-    if (step && answers[step.id] !== undefined && !theme?.disableAutoAdvance && autoAdvances) {
+    if (step && answers[step.id] !== undefined && advancesOnClick) {
       const stepAtSchedule = currentStep;
       const timer = setTimeout(() => {
         if (currentStepRef.current === stepAtSchedule) next();
@@ -392,7 +399,12 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   const enterKbdLabel = step?.type === 'textarea'
     ? (isMacPlatform ? '⌘ + Enter' : 'Ctrl + Enter')
     : 'Enter ↵';
-  const enterHint = showEnterHint ? (
+  // Steps answered by clicking an option advance on the click itself, so an
+  // "press Enter" hint is meaningless there — there is nothing to type and no
+  // button to reach. It stays for choice steps that do wait for the button
+  // (auto-advance turned off, or a multi-select with an "Other" box), where
+  // Enter really is the shortcut to continue.
+  const enterHint = showEnterHint && !advancesOnClick ? (
     <span className="form-enter-hint">
       {locale.enterHintBefore}<kbd>{enterKbdLabel}</kbd>{locale.enterHintAfter}
     </span>


### PR DESCRIPTION
Follow-up to #84. With the hint now visible in small embeds, it turned out to be showing on steps where it makes no sense.

## Problem

Single choice, multiple choice, yes/no, rating and image select are answered by clicking an option — and that click already advances the step (`AUTO_ADVANCE_FIELDS`). Telling the visitor to "press Enter" there points at a key that does nothing: there is no text to type, and pressing Enter with no answer yet just triggers the required-field error.

While tracing that, a second issue surfaced. `handleKeyDown` runs on the bubbled keypress and calls `preventDefault()` before advancing. Option rows are `<button>` elements, so a keyboard visitor tabbing to an option and pressing Enter had the button's own activation swallowed — the step advanced without recording the answer.

## Fix

- New `advancesOnClick` derived from the existing `autoAdvances` plus the theme's `disableAutoAdvance` flag, and used by both the auto-advance effect and the hint. The hint is suppressed whenever the click alone moves the visitor on.
- The hint still renders on choice steps that genuinely wait for the button: auto-advance disabled in the theme, or a multiple-choice step with an "Other" free-text box. Enter is a real shortcut in both cases.
- `handleKeyDown` now returns early when the keypress is aimed at a `button` or `a`, letting that element handle Enter itself. The Next button still advances — via its own click handler.

## Verification

`npm run build` in `frontend/` passes. Changes are confined to `FormRenderer.jsx`; no CSS, API or submission-shape changes.

## Version

Bumped to **0.21.3** (patch) across `README.md`, `CHANGELOG.md`, `backend/package.json` and `frontend/package.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNZtYhdFxhZ5DoJ5JnGj2X)_