### PR TITLE
Make the GDPR consent its own step, agreeable with Enter (v0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.23.0] - 2026-08-05
+
+### Changed
+- **The GDPR consent is now a step of its own, and can be agreed to with Enter** — the consent checkbox used to be appended under the last question, where the only way to tick it was to aim at a small box with a mouse or a thumb: a visitor who had answered the whole form from the keyboard had to leave it for that one click, right before submitting. Consent now gets its own final step, with the legal text on a large card that is easy to click or tap, and a hint next to the Submit button reading **press `Enter ↵` to agree**. One keystroke ticks the box and submits. The step's headline can be set in the editor (**GDPR / Submission Consent → Step Headline**) and defaults to "One last thing", localized. Clicking the card and then Submit still works exactly as before, as does tabbing to the box and pressing Space, and submitting without agreeing is still refused with the same message. The submitted data is unchanged — consent still arrives as `_consent: true` — and forms with the consent toggle off are untouched.
+  The extra step is counted in the progress bar and the step counter, and shows up in the funnel as **Consent**, so drop-off at the consent screen is finally visible instead of being hidden inside the last question's numbers.
+
 ## [0.22.1] - 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.22.1
+# 🌊 OpenFlow v0.23.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents
@@ -22,7 +22,7 @@
 - **Animated Backgrounds** — 4 stylish CSS motion presets (Waves, Bubbles, Aurora, Geometric) with 2-color support
 - **Configurable Button Position** — Place the "Next" button in the footer bar or inline below the input field
 - **Enter Key Hint** — Optional "press Enter" keyboard shortcut hint next to the Next button
-- **GDPR-Ready** — Consent checkbox auto-appended to the last step (form-level toggle)
+- **GDPR-Ready** — Consent asked as its own final step, agreed to with Enter or a click (form-level toggle)
 - **File Uploads** — Drag & drop with configurable file types and size limits
 
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.21.3",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.21.3",
+      "version": "0.23.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -96,7 +96,11 @@ router.get('/:formId', (req, res) => {
     },
     stepDropoff: stepEvents.map(se => {
       const s = steps[se.step_index];
-      const label = s?.type === 'group' && Array.isArray(s.fields)
+      // The GDPR consent is a step of its own at the end of the flow, but it isn't
+      // in the form's configured steps — name it rather than showing "Step 8".
+      const label = se.step_id === '__consent__'
+        ? 'Consent'
+        : s?.type === 'group' && Array.isArray(s.fields)
         ? s.fields.map(f => f.label || f.question).filter(Boolean).join(' + ') || `Step ${se.step_index + 1}`
         : s?.label || s?.question || `Step ${se.step_index + 1}`;
       return {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.21.3",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.21.3",
+      "version": "0.23.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.css
+++ b/frontend/src/components/FormRenderer.css
@@ -772,6 +772,31 @@
   color: var(--form-text, #2D3436);
 }
 
+/* Consent as its own step: a card the size of a choice option, so it is an easy
+   tap target and reads as the thing the step is asking for. */
+.form-consent-step {
+  align-items: center;
+  padding: 20px 22px;
+  border: 2px solid rgba(var(--form-text-rgb, 45, 52, 54), 0.12);
+  border-radius: 16px;
+  transition: all 0.2s;
+}
+
+.form-consent-step:hover {
+  border-color: var(--form-primary, #6C5CE7);
+  background: rgba(var(--form-primary-rgb, 108, 92, 231), 0.04);
+}
+
+.form-consent-step.checked {
+  border-color: var(--form-primary, #6C5CE7);
+  background: rgba(var(--form-primary-rgb, 108, 92, 231), 0.08);
+}
+
+.form-consent-step:focus-within {
+  outline: 2px solid var(--form-primary, #6C5CE7);
+  outline-offset: 2px;
+}
+
 /* Image / Icon Select Grid */
 .form-image-grid {
   display: grid;

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -179,6 +179,11 @@ export function toRgbTriplet(hex, fallback = '45, 52, 54') {
 
 const BG_SHAPES = { waves: 3, bubbles: 4, aurora: 3, particles: 6, flow: 4 };
 
+// Id and type of the synthetic consent step appended after the last question when
+// the form requires GDPR consent. It is not a configurable field, so it can never
+// collide with a nanoid field id, and its answer lives outside `answers`.
+export const CONSENT_STEP_ID = '__consent__';
+
 export default function FormRenderer({ form, onSubmit, embedded = false }) {
   const [currentStep, setCurrentStep] = useState(0);
   const [answers, setAnswers] = useState(() => initialAnswers(form.steps));
@@ -188,6 +193,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   const [direction, setDirection] = useState('forward');
   const containerRef = useRef(null);
   const trackedRef = useRef(false);
+  const submittingRef = useRef(false);
   // Always-current ref so auto-advance timer can check if user navigated away
   const currentStepRef = useRef(currentStep);
   useEffect(() => { currentStepRef.current = currentStep; }, [currentStep]);
@@ -195,9 +201,12 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   const allSteps = form.steps || [];
   const theme = form.theme || {};
   const locale = LOCALES[theme.language] || LOCALES.en;
+  const endScreen = form.end_screen || {};
+  const consentRequired = !!endScreen.consentEnabled;
+  const consentText = endScreen.consentText || locale.consentDefault;
 
   // Conditional logic: filter steps based on answers
-  const steps = allSteps.filter(s => {
+  const questionSteps = allSteps.filter(s => {
     if (!s.condition) return true;
     const { field, op, value } = s.condition;
     if (!field) return true;
@@ -214,12 +223,18 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
     }
   });
 
+  // The GDPR consent used to ride along as a checkbox under the last question, which
+  // only a mouse or a tap could reach — the visitor had to leave the keyboard for that
+  // one tick. It is now a step of its own at the end of the flow, so it can be agreed
+  // to with Enter the same way every other step is answered.
+  const steps = consentRequired
+    ? [...questionSteps, { id: CONSENT_STEP_ID, type: CONSENT_STEP_ID, question: endScreen.consentHeadline || locale.consentStepQuestion }]
+    : questionSteps;
+
   const progress = steps.length > 0 ? ((currentStep + 1) / steps.length) * 100 : 0;
   const step = steps[currentStep];
-  const endScreen = form.end_screen || {};
   const isLastStep = currentStep === steps.length - 1;
-  const consentRequired = !!endScreen.consentEnabled;
-  const consentText = endScreen.consentText || locale.consentDefault;
+  const isConsentStep = !!step && step.id === CONSENT_STEP_ID;
 
   const buttonPosition = theme.buttonPosition || 'footer';
   const showEnterHint = !!theme.showEnterHint;
@@ -261,6 +276,15 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   }
 
   const next = useCallback(function next() {
+    // The consent step has no field to validate — it is agreed to or it isn't.
+    if (isConsentStep) {
+      if (!consentGiven) {
+        setError(locale.errorConsentSubmit);
+        return;
+      }
+      handleSubmit();
+      return;
+    }
     for (const field of stepFields(step)) {
       const err = validateField(field, answers[field.id], locale);
       if (err) {
@@ -279,11 +303,6 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
         return;
       }
     }
-    // Check consent on last step
-    if (isLastStep && consentRequired && !consentGiven) {
-      setError(locale.errorConsentSubmit);
-      return;
-    }
     if (currentStep < steps.length - 1) {
       setDirection('forward');
       setCurrentStep(prev => prev + 1);
@@ -301,10 +320,15 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
     }
   }
 
-  async function handleSubmit() {
+  // `consentOverride` covers the Enter shortcut, which agrees and submits in one
+  // keystroke: the state update it triggers isn't visible to this call yet.
+  async function handleSubmit(consentOverride) {
+    // A held-down or double-tapped Enter must not post the form twice.
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     const submitData = { ...answers };
     if (consentRequired) {
-      submitData._consent = consentGiven;
+      submitData._consent = consentOverride === undefined ? consentGiven : consentOverride;
     }
     try {
       await onSubmit(submitData);
@@ -318,8 +342,18 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
         });
       }
     } catch (err) {
+      // Failed sends have to stay retryable.
+      submittingRef.current = false;
       setError(err.message || locale.errorSubmitFailed);
     }
+  }
+
+  // Enter on the consent step is itself the affirmative action the screen asks for:
+  // it ticks the box and submits, so agreeing never requires reaching for a pointer.
+  function agreeAndSubmit() {
+    setConsentGiven(true);
+    setError('');
+    handleSubmit(true);
   }
 
   function handleKeyDown(e) {
@@ -328,11 +362,42 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
     // option, the Next button, a footer link. Advancing here instead would eat
     // the keystroke and skip the step without recording the answer.
     if (e.target.closest?.('button, a')) return;
+    // The consent step is served by the window listener below, so the keystroke
+    // isn't handled twice — and therefore never submits twice.
+    if (isConsentStep) return;
     // Textareas need plain Enter for newlines; only advance on Ctrl/Cmd+Enter.
     if (step?.type === 'textarea' && !(e.metaKey || e.ctrlKey)) return;
     e.preventDefault();
     next();
   }
+
+  // Unlike a question step, the consent step has no text input holding the caret,
+  // so after arriving from the previous step a keystroke lands on the document
+  // body — outside the container's own handler, which would never see it.
+  // Listening on the window keeps Enter working wherever focus happens to sit.
+  const agreeRef = useRef(agreeAndSubmit);
+  agreeRef.current = agreeAndSubmit;
+  useEffect(() => {
+    if (!isConsentStep || submitted) return;
+    // The keystroke that advanced onto this step is still travelling towards the
+    // window as this listener goes up, and holding the key sends repeats after it.
+    // Arming on the next task, and ignoring auto-repeats, keeps one press from
+    // answering the previous step and agreeing here in the same breath.
+    let armed = false;
+    const armTimer = setTimeout(() => { armed = true; }, 0);
+    function onKey(e) {
+      if (!armed || e.repeat || e.key !== 'Enter') return;
+      // Enter on a focused button or link has to activate that element instead.
+      if (e.target.closest?.('button, a')) return;
+      e.preventDefault();
+      agreeRef.current();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => {
+      clearTimeout(armTimer);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [isConsentStep, submitted]);
 
   // Track form view on mount
   useEffect(() => {
@@ -447,7 +512,15 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   // button to reach. It stays for choice steps that do wait for the button
   // (auto-advance turned off, or a multi-select with an "Other" box), where
   // Enter really is the shortcut to continue.
-  const enterHint = showEnterHint && !advancesOnClick ? (
+  // On the consent step the hint carries the keyboard shortcut that replaces the
+  // click, so it is shown whether or not the form enables hints elsewhere —
+  // without it the Enter path is invisible. CSS still hides it on touch devices,
+  // where there is no keyboard and the box is tapped instead.
+  const enterHint = isConsentStep ? (
+    <span className="form-enter-hint">
+      {locale.consentEnterBefore}<kbd>Enter ↵</kbd>{locale.consentEnterAfter}
+    </span>
+  ) : showEnterHint && !advancesOnClick ? (
     <span className="form-enter-hint">
       {locale.enterHintBefore}<kbd>{enterKbdLabel}</kbd>{locale.enterHintAfter}
     </span>
@@ -504,11 +577,19 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
               {step.description && <p className="step-description">{step.description}</p>}
 
               <div className="step-field">
-                <FieldComponent
-                  step={displayStep}
-                  value={answers[step.id]}
-                  onChange={setAnswer}
-                />
+                {isConsentStep ? (
+                  <ConsentStepInput
+                    text={consentText}
+                    checked={consentGiven}
+                    onChange={checked => { setConsentGiven(checked); setError(''); }}
+                  />
+                ) : (
+                  <FieldComponent
+                    step={displayStep}
+                    value={answers[step.id]}
+                    onChange={setAnswer}
+                  />
+                )}
                 {buttonPosition === 'below-input' && (
                   <div className="form-below-input-actions">
                     {nextButton}
@@ -525,14 +606,6 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
                 </div>
               )}
             </>
-          )}
-
-          {/* GDPR consent on last step */}
-          {isLastStep && consentRequired && (
-            <label className="form-consent" style={{ marginTop: 24 }}>
-              <input type="checkbox" checked={consentGiven} onChange={e => { setConsentGiven(e.target.checked); setError(''); }} />
-              <span className="consent-text">{consentText}</span>
-            </label>
           )}
 
           {error && <p className="step-error">{error}</p>}
@@ -1014,6 +1087,18 @@ function AddressInput({ step, value, onChange }) {
         </div>
       ))}
     </div>
+  );
+}
+
+// The GDPR consent as its own step: a large, tappable card that is also the target
+// of the Enter shortcut. The checkbox stays a real checkbox so a pointer, a tap and
+// the Tab/Space route all keep working.
+function ConsentStepInput({ text, checked, onChange }) {
+  return (
+    <label className={`form-consent form-consent-step${checked ? ' checked' : ''}`}>
+      <input type="checkbox" checked={checked} onChange={e => onChange(e.target.checked)} autoFocus />
+      <span className="consent-text">{text}</span>
+    </label>
   );
 }
 

--- a/frontend/src/locales.js
+++ b/frontend/src/locales.js
@@ -34,6 +34,9 @@ export const LOCALES = {
     yes: 'Yes',
     no: 'No',
     consentDefault: 'I agree to the privacy policy and terms of service.',
+    consentStepQuestion: 'One last thing',
+    consentEnterBefore: 'press ',
+    consentEnterAfter: ' to agree',
     // Calendar. weekdayShort is always Sunday-first (matching Date#getDay);
     // the calendar rotates it by weekStartsOn when it draws the header row.
     weekStartsOn: 0,
@@ -84,6 +87,9 @@ export const LOCALES = {
     yes: 'Ja',
     no: 'Nein',
     consentDefault: 'Ich stimme der Datenschutzerklärung und den Nutzungsbedingungen zu.',
+    consentStepQuestion: 'Noch eine Kleinigkeit',
+    consentEnterBefore: '',
+    consentEnterAfter: ' drücken, um zuzustimmen',
     weekStartsOn: 1,
     weekdayShort: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
     monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -642,7 +642,8 @@ export default function FormEditor() {
           <div className="card">
             <h3 style={{ marginBottom: 4 }}>GDPR / Submission Consent</h3>
             <p style={{ color: 'var(--text-light)', fontSize: 13, marginBottom: 16 }}>
-              When enabled, a consent checkbox is automatically shown on the last step of the form before submission.
+              When enabled, the consent is asked as its own final step before submission. Visitors can agree by pressing
+              Enter — the step shows that hint — or by clicking the box and then Submit.
             </p>
             <label style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 15, fontWeight: 600, marginBottom: 16, cursor: 'pointer' }}>
               <input
@@ -654,16 +655,27 @@ export default function FormEditor() {
               Require consent before submission
             </label>
             {form.end_screen?.consentEnabled && (
-              <div className="input-group">
-                <label>Consent Text</label>
-                <textarea
-                  className="input"
-                  rows={3}
-                  value={form.end_screen?.consentText || 'I agree to the privacy policy and terms of service.'}
-                  onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, consentText: e.target.value } })}
-                  placeholder="I agree to the privacy policy and terms of service."
-                />
-              </div>
+              <>
+                <div className="input-group">
+                  <label>Step Headline (optional)</label>
+                  <input
+                    className="input"
+                    value={form.end_screen?.consentHeadline || ''}
+                    onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, consentHeadline: e.target.value } })}
+                    placeholder="One last thing"
+                  />
+                </div>
+                <div className="input-group">
+                  <label>Consent Text</label>
+                  <textarea
+                    className="input"
+                    rows={3}
+                    value={form.end_screen?.consentText || 'I agree to the privacy policy and terms of service.'}
+                    onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, consentText: e.target.value } })}
+                    placeholder="I agree to the privacy policy and terms of service."
+                  />
+                </div>
+              </>
             )}
           </div>
 


### PR DESCRIPTION
## What

The GDPR consent checkbox used to be appended under the last question, so the only way to tick it was to aim at a small box with a mouse or a thumb — a visitor who had answered the whole form from the keyboard had to leave it for that one click, right before submitting.

Consent is now **its own final step**:

- The legal text sits on a large card that is easy to click or tap.
- The hint next to the Submit button reads **press `Enter ↵` to agree** — one keystroke ticks the box and submits.
- The step's headline is configurable in the editor (**GDPR / Submission Consent → Step Headline**) and defaults to a localized "One last thing" / "Noch eine Kleinigkeit".

Unchanged: clicking the card and then Submit, tabbing to the box and pressing Space, the refusal message when submitting without agreeing, and the submitted payload (`_consent: true`). Forms with the consent toggle off are untouched — no extra step, same flow as before.

The extra step counts towards the progress bar and step counter, and shows up in the funnel as **Consent** rather than a bare step number, so drop-off at the consent screen is finally visible.

## Implementation notes

- `FormRenderer` appends a synthetic step (`__consent__`) after the conditional-logic filter when `end_screen.consentEnabled` is set; its answer stays outside `answers`, so field ids and submitted data are unaffected.
- Enter is handled by a **window-level** listener while the consent step is showing: unlike a question step there is no text input holding the caret, so the keystroke otherwise lands on `document.body`, outside the renderer's own handler.
- That listener is armed one task late and ignores `e.repeat`, so the keystroke that advances *onto* the step cannot also agree on it, and holding Enter does not skip through. A submit-in-flight guard keeps a double press from posting twice (failed sends stay retryable).
- The hint is shown on this step regardless of the theme's "Enter key hint" setting — without it the shortcut is invisible — and the existing `(hover: none) and (pointer: coarse)` rule still hides it on touch devices, where the box is tapped instead.

## Testing

Driven in a real browser (Chromium/Playwright) against the renderer:

- keyboard only: answer → Enter → consent step → Enter ⇒ submitted `{"q1":"Ada","_consent":true}`
- mouse: click the card, then Submit ⇒ same payload
- Submit without agreeing ⇒ "You must agree to the consent to submit.", nothing sent; Back returns to the question with the answer intact
- holding Enter on the question step ⇒ lands on the consent step, does **not** submit
- Tab/Space route ⇒ box checked, then Enter submits
- German locale ⇒ "Noch eine Kleinigkeit" / "Enter ↵ drücken, um zuzustimmen"
- consent toggle off ⇒ 1/1 steps, submits as before with no `_consent`

`cd frontend && npm run build` passes. Backend suite: 109 passed, 5 failed — the same 5 failures are present on `main` without this change (auth user-deletion and one analytics event-type case), so they are pre-existing and unrelated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FB4VB9jUucDKFev6WEKRys)_