### PR TITLE
Make agreeing to the GDPR consent a press of its own (v0.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.25.0] - 2026-08-06
+
+### Changed
+- **Agreeing to the consent is now a press of its own** — 0.24.0 let a single `Enter` finish the last question, tick the consent box and send the form in one keystroke. That is the wrong thing to do with a consent: it made agreeing a side effect of answering, so the visitor could hardly be said to have given it deliberately. The last step still holds the question and the checkbox on one page, but the flow is now two presses. While the answer is being written the hint sits under the field — **press `Enter ↵` to confirm** — and that first press only confirms the answer: nothing is ticked, nothing is sent. The hint then moves down below the checkbox, where it reads **press `Enter ↵` to agree and submit**, and the second press is the agreement itself. Editing the answer afterwards takes the confirmation back and the hint returns to the field, and a held-down `Enter` is ignored on this step, so the two presses can never collapse into one.
+  Everything else on the step is unchanged: ticking the box by hand still shows "to submit" and skips straight to sending, Submit with the box untouched is still refused (now with the hint below the box pointing at the way to give it), a last step answered by clicking still hands focus to the checkbox, and the consent still arrives as `_consent: true`. Both hints keep their line whether or not they are showing, so the step doesn't resize between presses, and neither reserves space on touch devices, where there is no keyboard to hint at. The separate consent screen (**Where to Ask → As its own final step**) is unaffected — it is a step of its own, so agreeing there is already an act of its own.
+
 ## [0.24.0] - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.24.0
+# 🌊 OpenFlow v0.25.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents
@@ -22,7 +22,7 @@
 - **Animated Backgrounds** — 4 stylish CSS motion presets (Waves, Bubbles, Aurora, Geometric) with 2-color support
 - **Configurable Button Position** — Place the "Next" button in the footer bar or inline below the input field
 - **Enter Key Hint** — Optional "press Enter" keyboard shortcut hint next to the Next button
-- **GDPR-Ready** — Consent under the last question or as its own final step, agreed to with Enter or a click (form-level toggle)
+- **GDPR-Ready** — Consent under the last question or as its own final step, agreed to by a deliberate press of Enter or a click (form-level toggle)
 - **File Uploads** — Drag & drop with configurable file types and size limits
 
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.css
+++ b/frontend/src/components/FormRenderer.css
@@ -785,6 +785,27 @@
   padding-left: 38px;
 }
 
+/* First half of the inline consent flow: the hint that offers to confirm the answer,
+   sitting under the field it belongs to and above the consent it leads to. */
+/* Both hints of the inline flow keep their line whether or not they are showing, so
+   handing over from one to the other doesn't resize the step under the visitor. */
+.form-consent-confirm,
+.form-consent-inline .form-consent-hint-slot {
+  min-height: 22px;
+}
+
+.form-consent-confirm {
+  margin-top: 14px;
+}
+
+/* Nothing to reserve where the hints never show. */
+@media (hover: none) and (pointer: coarse) {
+  .form-consent-confirm,
+  .form-consent-inline .form-consent-hint-slot {
+    display: none;
+  }
+}
+
 /* Consent as its own step: a card the size of a choice option, so it is an easy
    tap target and reads as the thing the step is asking for. */
 .form-consent-step {

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -188,6 +188,10 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   const [currentStep, setCurrentStep] = useState(0);
   const [answers, setAnswers] = useState(() => initialAnswers(form.steps));
   const [consentGiven, setConsentGiven] = useState(false);
+  // Inline consent is a two-press flow: the first Enter confirms the last answer,
+  // the second one agrees. This marks that the first has happened, so the consent
+  // is never carried along by the keystroke that finished the question.
+  const [answerConfirmed, setAnswerConfirmed] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState('');
   const [direction, setDirection] = useState('forward');
@@ -266,6 +270,9 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   function setFieldAnswer(fieldId, value) {
     setAnswers(prev => ({ ...prev, [fieldId]: value }));
     setError('');
+    // Editing an answer takes the confirmation back: the hint returns to the field
+    // until the visitor confirms what they now wrote.
+    setAnswerConfirmed(false);
   }
 
   function setAnswer(value) {
@@ -304,6 +311,10 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
   const showInlineConsent = consentInline && isLastStep;
   const inlineConsentReady = showInlineConsent && stepReady;
+  // The second half of the inline flow: the answer is in and confirmed (or the box
+  // was ticked by hand), so the hint has moved down to the checkbox and the next
+  // Enter is the agreement itself — nothing else.
+  const consentAwaited = inlineConsentReady && (answerConfirmed || consentGiven);
 
   // `opts.agree` marks a keystroke as the affirmative act the consent asks for:
   // Enter ticks the box and submits, where the Submit button still wants the box
@@ -325,10 +336,26 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
       setError(err);
       return;
     }
-    // Inline consent sits under the last step's field: the same Enter that would
-    // submit the form agrees on the way out.
+    // Inline consent sits under the last step's field, and reaching it takes two
+    // presses: consent has to be a deliberate act of its own, never something the
+    // keystroke that finished the last answer carries along with it.
     if (isLastStep && consentInline) {
-      if (!consentGiven && !agree) {
+      // Box already ticked — by hand, or by the Enter that agreed a moment ago.
+      if (consentGiven) {
+        handleSubmit(true);
+        return;
+      }
+      // First press: the answer is accepted and the hint moves down to the
+      // checkbox. Nothing is agreed to and nothing is sent yet.
+      if (!answerConfirmed) {
+        setAnswerConfirmed(true);
+        // The Submit button is not an agreement, so it still says what is missing —
+        // now with the hint underneath the box pointing at the way to give it.
+        if (!agree) setError(locale.errorConsentSubmit);
+        return;
+      }
+      // Second press, with the answer already confirmed: this one is the consent.
+      if (!agree) {
         setError(locale.errorConsentSubmit);
         return;
       }
@@ -386,6 +413,9 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
   // that actually asks for consent.
   function handleKeyDown(e) {
     if (e.key !== 'Enter') return;
+    // A held Enter must not run the confirmation and the consent behind it together:
+    // each of the two presses on this screen has to be a press of its own.
+    if (e.repeat && (isConsentStep || showInlineConsent)) return;
     // Enter on a focused button or link has to activate that element — a choice
     // option, the Next button, a footer link. Advancing here instead would eat
     // the keystroke and skip the step without recording the answer.
@@ -452,6 +482,9 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
       }
     }
   }, [currentStep]);
+
+  // Leaving a step drops its confirmation: coming back has to ask again.
+  useEffect(() => { setAnswerConfirmed(false); }, [currentStep]);
 
   const AUTO_ADVANCE_FIELDS = ['select', 'multi-select', 'yes-no', 'rating', 'image-select'];
 
@@ -580,9 +613,26 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
     </span>
   ) : null;
 
-  // Inline consent brings its own hint, right under the checkbox, so the one by the
-  // button would only say the same thing twice.
+  // The last step of an inline-consent form carries its own pair of hints, one after
+  // the other, so the one by the button would only get in their way.
   const stepEnterHint = showInlineConsent ? null : enterHint;
+
+  // Both hints of the inline flow belong to the consent path, so — like the consent
+  // step's hint — they show whether or not the form uses hints elsewhere: without
+  // them the two presses are invisible. The first sits under the field the visitor
+  // just filled in and offers to confirm it; once it is confirmed the hint is gone
+  // from there and the one under the checkbox has taken over.
+  // The slot is always there once the consent is on the step, so the checkbox below
+  // it doesn't jump up as the hint hands over to the one underneath it.
+  const consentConfirmHint = showInlineConsent ? (
+    <div className="form-consent-confirm">
+      {inlineConsentReady && !consentAwaited && (
+        <span className="form-enter-hint">
+          {locale.enterHintBefore}<kbd>{enterKbdLabel}</kbd>{locale.consentEnterConfirmAfter}
+        </span>
+      )}
+    </div>
+  ) : null;
 
   const consentBlock = showInlineConsent ? (
     <div className="form-consent-inline">
@@ -595,13 +645,17 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
         />
         <span className="consent-text">{consentText}</span>
       </label>
-      {inlineConsentReady && (
-        <span className="form-enter-hint">
-          {locale.consentEnterBefore}
-          <kbd>{enterKbdLabel}</kbd>
-          {consentGiven ? locale.consentEnterSubmitAfter : locale.consentEnterAgreeSubmitAfter}
-        </span>
-      )}
+      {/* Reserved like the slot above it: the two hints take turns without the step
+          resizing under the visitor between the presses. */}
+      <div className="form-consent-hint-slot">
+        {consentAwaited && (
+          <span className="form-enter-hint">
+            {locale.consentEnterBefore}
+            <kbd>{enterKbdLabel}</kbd>
+            {consentGiven ? locale.consentEnterSubmitAfter : locale.consentEnterAgreeSubmitAfter}
+          </span>
+        )}
+      </div>
     </div>
   ) : null;
 
@@ -642,6 +696,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
           {step.type === 'group' ? (
             <>
               <GroupInput step={step} answers={answers} setFieldAnswer={setFieldAnswer} />
+              {consentConfirmHint}
               {consentBlock}
               {(buttonPosition === 'below-input' || buttonPosition === 'inline') && (
                 <div className={buttonPosition === 'below-input' ? 'form-below-input-actions' : 'form-inline-actions'}>
@@ -670,6 +725,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
                     onChange={setAnswer}
                   />
                 )}
+                {consentConfirmHint}
                 {consentBlock}
                 {buttonPosition === 'below-input' && (
                   <div className="form-below-input-actions">

--- a/frontend/src/locales.js
+++ b/frontend/src/locales.js
@@ -39,6 +39,8 @@ export const LOCALES = {
     consentEnterAfter: ' to agree',
     consentEnterAgreeSubmitAfter: ' to agree and submit',
     consentEnterSubmitAfter: ' to submit',
+    // Shown under the last field, before the consent below it is touched.
+    consentEnterConfirmAfter: ' to confirm',
     // Calendar. weekdayShort is always Sunday-first (matching Date#getDay);
     // the calendar rotates it by weekStartsOn when it draws the header row.
     weekStartsOn: 0,
@@ -94,6 +96,7 @@ export const LOCALES = {
     consentEnterAfter: ' drücken, um zuzustimmen',
     consentEnterAgreeSubmitAfter: ' drücken, um zuzustimmen und abzusenden',
     consentEnterSubmitAfter: ' drücken zum Absenden',
+    consentEnterConfirmAfter: ' drücken zum Bestätigen',
     weekStartsOn: 1,
     weekdayShort: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
     monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',

--- a/frontend/src/pages/FormEditor.jsx
+++ b/frontend/src/pages/FormEditor.jsx
@@ -665,13 +665,13 @@ export default function FormEditor() {
                     onChange={e => setForm({ ...form, end_screen: { ...form.end_screen, consentMode: e.target.value } })}
                     style={{ maxWidth: 340 }}
                   >
-                    <option value="inline">On the last step — one page, one more Enter</option>
+                    <option value="inline">On the last step — one page, two presses of Enter</option>
                     <option value="step">As its own final step</option>
                   </select>
                   <p style={{ color: 'var(--text-light)', fontSize: 13, marginTop: 6 }}>
                     {form.end_screen?.consentMode === 'step'
                       ? 'The consent gets a screen of its own after the last question.'
-                      : 'The checkbox sits under the last question. Once that question is answered, a hint appears below it and one more Enter agrees and submits.'}
+                      : 'The checkbox sits under the last question. Enter confirms the answer first; only then does the hint move below the checkbox, where a second Enter is the agreement itself.'}
                   </p>
                 </div>
                 {form.end_screen?.consentMode === 'step' && (


### PR DESCRIPTION
## Why

0.24.0 let a single `Enter` on the last step finish the question, tick the consent box and send the form in one keystroke. That makes the agreement a side effect of answering — the visitor never performs a separate, deliberate act of consent, which is exactly what the checkbox is there to record.

## What changed

The last step still holds the question and the checkbox on one page. The keyboard path is now two presses:

1. **While the answer is being written**, the hint sits under the field: *press `Enter ↵` to confirm*. That first press only accepts the answer — nothing is ticked, nothing is sent.
2. **The hint then moves below the checkbox**: *press `Enter ↵` to agree and submit*. The second press is the agreement itself.

Supporting details:

- Editing the answer after confirming takes the confirmation back — the hint returns to the field.
- A held-down `Enter` is ignored on the consent screens, so the two presses can never collapse into one.
- Leaving the step (back arrow) drops the confirmation; coming back asks again.
- Both hints keep their line whether or not they are showing, so the step doesn't resize between the presses. Neither reserves space on touch devices, where the hints are hidden anyway.
- German wording added: *Enter ↵ drücken zum Bestätigen*.

Unchanged: ticking the box by hand still reads "to submit" and sends on the next `Enter`/Submit; Submit with the box untouched is still refused (now with the hint below the box pointing at the way to give it); a last step answered by clicking still hands focus to the checkbox; consent still arrives as `_consent: true`; forms with consent off are untouched. The separate consent screen (**Where to Ask → As its own final step**) is unaffected — agreeing there is already an act of its own.

## Files

- `frontend/src/components/FormRenderer.jsx` — two-phase inline consent (`answerConfirmed` state, the split in `next()`, the repeat guard, the confirm hint under the field)
- `frontend/src/components/FormRenderer.css` — reserved hint lines, hidden on touch
- `frontend/src/locales.js` — `consentEnterConfirmAfter` (en/de)
- `frontend/src/pages/FormEditor.jsx` — the "Where to Ask" wording now describes two presses
- `README.md`, `CHANGELOG.md`, `backend/package.json`, `frontend/package.json` + lockfiles — v0.25.0

## Testing

Driven in Chromium against a temporary harness of the renderer:

- text last step: hint under the field after typing → first `Enter` moves it under the box, nothing submitted → second `Enter` submits with `_consent: true`
- edit after confirming → hint back at the field; confirm again → submits
- held `Enter` → stops at the checkbox, never submits
- invalid last answer → error, no hint moves
- Submit button without ticking → refused twice, hint sits under the box
- tick by hand → "to submit", one `Enter`/Submit sends
- choice last step (auto-advance held) → click, focus lands on the box, then the same two presses
- textarea last step → `Ctrl + Enter` twice; a plain `Enter` types a newline and takes the confirmation back
- optional last field, back-and-forward, button positions footer/inline/below-input, hints turned off, German, consent off, own-step mode
- layout measured across all three states: step height constant at 293px, nothing shifts
- `npm run build` (frontend) clean; backend `jest` — 109 pass, the same 5 failures that reproduce on unmodified `main` (unrelated: user-deletion auth, analytics event type)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FB4VB9jUucDKFev6WEKRys)_