### PR TITLE
Bring the public docs back in line with the code (v0.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.25.1] - 2026-08-09
+
+### Docs
+
+Full review of the public documentation against the code. No behaviour changes.
+
+- **`CLAUDE.md` had drifted a long way out of date** — it still claimed version 0.14.0 (eleven releases behind) and described a database that doesn't exist: a `fields` table for form steps (steps are a JSON column on `forms`) and a `submissions_events` table for analytics (it's `analytics_events`). The eight tables added since — `analytics_events`, `integration_deliveries`, `api_tokens`, `slug_history`, `site_settings` — were missing entirely, as were the delivery queue, backups, API tokens, subdomain middleware and the `utils/` helpers. Infrastructure was described as "backend and frontend services" when the compose file has run a single `app` service since the frontend was folded into the backend image. The "add a field type" recipe pointed at `models/db.js` for validation, which has never held any; field types are defined in `FormEditor.jsx`, validated in `FormRenderer.jsx`, and the server's only check lives in `routes/public.js`. "Field IDs: nanoid" was also wrong — nanoid generates form *slugs*; field ids are `field_<timestamp>`.
+- **The README described a 15th field type that can't be added** — Consent/GDPR was listed among the field types and in the field-type table, but it has been a form-level setting since 0.23.0, not something the builder can insert. It's now documented as what it is, with the count corrected to 14.
+- **The README listed animated backgrounds that don't exist** — "4 presets (Waves, Bubbles, Aurora, Geometric)". There are five, and none of them is Geometric: Waves, Bubbles, Aurora, Particles, Flow.
+- **Features shipped between 0.11.0 and 0.21.0 were missing from the README** — combined steps, the flat-rate pricing filter, form duplication, the end screen's auto-redirect, the form language setting, editable Next/Submit labels, the live theme preview, white-label branding, and the cookie consent banner that gates GTM (which now has a section of its own under GTM Events, since it also gates the ad click IDs the Google Ads integration needs).
+- **The configuration table was missing two variables and misstated two defaults** — `CORS_ORIGINS` and `OPENFLOW_PRIMARY_HOST` were undocumented, and `JWT_SECRET`/`ADMIN_PASSWORD` were listed with the `docker-compose.yml` fallbacks as if they were the app's defaults. Since 0.16.0 the app generates both when unset, which is what you get running the backend outside compose. Both are now labelled by origin, with the same note added to Quick Start so `admin123` doesn't read as a permanent default.
+- **The API reference was about half the surface** — added the auth (`logout`, `me`), form-clone, submission-delete, settings, API-token and backup/restore endpoints, and a note that read-only tokens work on any GET/HEAD endpoint listed.
+- **Refreshed the architecture tree and roadmap** — the tree omitted `tests/`, `utils/`, `docs/`, the Caddy overlay and the fact that the Dockerfile builds the frontend into the backend image. The roadmap still had "custom domain support" as upcoming, which shipped in 0.11.0 as per-form subdomains.
+- **Documented the webhook payload properly, including a signing bug found while checking it** — the README listed the payload as `formId`, `formTitle`, `data`, `timestamp` and never named the signature header. The delivered body also carries `event: "submission"`, the header is `X-OpenFlow-Signature`, and the SSRF check plus the no-redirect rule are worth stating. Checking that claim turned up a real defect: the HMAC is computed over `{formId, formTitle, data, timestamp: Date.now()}` while the body actually sent is `{event, formId, formTitle, data, timestamp: <ISO string>}`, so a receiver verifying the signature against the bytes it received can never get a match. That is a code fix, not a docs fix, so the behaviour is unchanged here and the README carries a warning until it lands.
+- **WordPress plugin metadata contradicted the project's licence** — `openflow.php` and `readme.txt` both declared MIT inside a GPL-3.0 repository; both now declare GPL-3.0, and the plugin header's `Plugin URI` no longer points at the `your-org` placeholder.
+
 ## [0.25.0] - 2026-08-06
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets), analytics, and a WordPress plugin.
+**OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets, Google Ads), analytics, and a WordPress plugin.
 
-**Current Version**: 0.14.0 (see version badge in README.md and CHANGELOG.md)
+**Current Version**: 0.25.1 (see version badge in README.md and CHANGELOG.md)
 
 ## Architecture
 
@@ -16,36 +16,51 @@ OpenFlow is a **full-stack application** with three main components:
 - **Location**: `backend/src/`
 - **Technology**: Node.js + Express.js + SQLite (better-sqlite3)
 - **Key Files**:
-  - `index.js` — Server entry point, route initialization
-  - `models/db.js` — Database schema and migrations
-  - `models/integrations.js` — Integration engine (webhooks, email, Google Sheets)
-  - `middleware/auth.js` — JWT authentication
-  - `routes/` — API endpoints (forms, submissions, integrations, analytics, auth)
+  - `index.js` — Server entry point, CORS, route initialization, SPA fallback
+  - `models/db.js` — Database schema, migrations, first-boot admin seeding
+  - `models/integrations.js` — Integration engine (webhooks, email, Google Sheets, Google Ads)
+  - `models/deliveryQueue.js` — Persists each integration delivery and retries it with backoff
+  - `models/backup.js` / `models/backupScheduler.js` — JSON backup/restore + the rotating scheduled backup job
+  - `models/apiTokens.js` — Read-only `ofw_` API tokens (hashed at rest)
+  - `models/rateLimit.js` — In-memory rate limiter
+  - `middleware/auth.js` — JWT + API-token authentication, `requireAdmin`, `requireSession`
+  - `middleware/subdomain.js` — Resolves per-form subdomains and blocks admin paths on them
+  - `routes/` — API endpoints (auth, forms, submissions, public, integrations, analytics, settings, admin)
+  - `utils/` — `steps.js` (flattens combined steps), `slug.js`, `subdomain.js`, `sanitizeCss.js`, `ssrf.js`
 - **Database**: SQLite stored in Docker volume (`db-data`) for persistence
-- **Key Features**: Rate limiting, JWT auth, HMAC-signed webhooks, SMTP email, Google Sheets integration, analytics tracking
+- **Key Features**: Rate limiting, JWT auth, read-only API tokens, HMAC-signed webhooks, SMTP email, Google Sheets/Ads integrations, retrying deliveries, analytics tracking, backup & restore
 
 ### Frontend (React + Vite)
 - **Location**: `frontend/src/`
 - **Technology**: React 18 + Vite + React Router
 - **Key Files**:
-  - `pages/FormEditor.jsx` — Form builder UI (add fields, conditional logic, theme settings)
-  - `pages/FormView.jsx` — Public form display (read-only preview)
-  - `pages/Dashboard.jsx` — Admin panel (list forms, manage users)
+  - `main.jsx` — Route split: `/f/:slug`, `/embed/:slug`, everything else the admin SPA (plus per-form subdomain mode)
+  - `App.jsx` — Admin shell (sidebar, auth gate, theme toggle)
+  - `pages/FormEditor.jsx` — Form builder UI (`FIELD_TYPES` lives here; steps, end screen, design, GTM/GDPR, integrations, embed tabs)
+  - `pages/FormView.jsx` — Public form page at `/f/:slug` (landing page, GTM, cookie banner)
+  - `pages/EmbedView.jsx` — Iframe-optimized form page at `/embed/:slug` (posts resize messages)
+  - `pages/Dashboard.jsx` — Form list (create, duplicate, publish, delete)
   - `pages/Analytics.jsx` — Funnel and drop-off analysis
-  - `pages/Submissions.jsx` — View and export submissions
-  - `components/FormRenderer.jsx` — Renders published forms with animations and validations
-  - `components/IntegrationsPanel.jsx` — Configure webhooks, email, Google Sheets per form
+  - `pages/Submissions.jsx` — View, delete and export submissions
+  - `pages/Users.jsx` / `pages/Settings.jsx` / `pages/Backup.jsx` — Admin-only pages (users, branding + API tokens, backup/restore)
+  - `components/FormRenderer.jsx` — Renders forms with animations, validation, conditional logic and consent
+  - `components/IntegrationsPanel.jsx` — Configure integrations per form
+  - `components/AdminUI.jsx` — Shared page header, alert, empty/loading components
+  - `locales.js` — Built-in respondent-facing UI strings (EN / DE)
 - **API Client**: `api.js` — Wrapper for backend API calls
 - **Dev Server**: Vite with proxy to backend (port 3000)
 
 ### WordPress Plugin
 - **Location**: `wordpress-plugin/openflow/`
 - **Features**: Shortcode `[openflow]`, WPBakery element, Gutenberg block
-- **Key Files**: `openflow.php`, `block.js`
+- **Key Files**: `openflow.php`, `block.js`, `readme.txt`
+- **Versioning**: The plugin carries its **own** version (`OPENFLOW_VERSION` in `openflow.php` + the `Stable tag` in `readme.txt`), independent of the app version
 
 ### Infrastructure
-- **Docker**: Single `docker-compose.yml` with backend and frontend services
+- **Docker**: A single `app` service in `docker-compose.yml`. The multi-stage `Dockerfile` builds the frontend and copies `dist/` into the backend's `public/`, so one container serves both the API and the UI.
+- **Optional overlay**: `docker-compose.subdomains.yml` + `Caddyfile` add a Caddy reverse proxy that terminates TLS with a wildcard cert, for per-form subdomains
 - **Database**: SQLite (zero-config, no external DB)
+- **Volumes**: `db-data` (the SQLite DB) and a `./backups` bind mount (scheduled backups)
 - **Deployment**: Docker Compose (one-command deployment)
 
 ## Development Setup
@@ -72,30 +87,53 @@ docker compose up -d --build
 # Access at http://localhost:3000
 # Default login: admin@openflow.local / admin123
 ```
+`docker-compose.yml` supplies `admin123` as the fallback `ADMIN_PASSWORD`. Running
+the backend **without** those compose defaults generates a random one-time admin
+password and prints it to the server log on first boot instead.
 
 ## Key Development Patterns
 
 ### Form Structure (Backend)
-A form is a document with:
-- **Fields**: Array of steps, each with field type, label, placeholder, validation, etc.
-- **Theme**: Colors, fonts, animated backgrounds, button position
-- **Integrations**: Webhooks, email notifications, Google Sheets
-- **Landing Page**: Optional logo, headline, subline, footer links
+A form row in `forms` holds everything as JSON columns — there is no separate
+fields table:
+- **`steps`**: Array of steps, each with field type, label, placeholder, validation, etc. A step is normally one field; two adjacent questions can be merged into a `{ type: 'group', fields: [a, b] }` step. Use `utils/steps.js#flattenFields` before touching leaf fields.
+- **`theme`**: Colors, fonts, animated backgrounds, button position, custom CSS, language
+- **`end_screen`**: Thank-you content, auto-redirect, GDPR consent settings, cookie-banner settings
+- **`gtm_id`**: GTM container id (validated as `GTM-XXXXXXX`, since it is interpolated into a raw `<script>` tag)
+- **Integrations**: Rows in the `integrations` table, keyed by `form_id`
+- **Landing Page**: Optional logo, headline, subline, footer links (in `theme`)
 - **Conditional Logic**: Show/hide rules based on previous answers (stored in step config)
 
 ### Form Field Types
-15 types: Short Text, Long Text, Number, Date, Single Choice, Multiple Choice, Yes/No, Rating, Image/Icon Select, File Upload, Email, Phone, Website URL, Address, Consent/GDPR. Each has validation, placeholder, help text, and conditional visibility.
+14 types the builder can add (`FIELD_TYPES` in `frontend/src/pages/FormEditor.jsx`):
+Short Text, Long Text, Number, Date, Single Choice, Multiple Choice, Yes/No,
+Rating, Image/Icon Select, File Upload, Email, Phone, Website URL, Address. Each
+has validation, placeholder, help text, and conditional visibility.
+
+**Consent/GDPR is not a field type** — it's a form-level setting (**GTM / GDPR**
+tab) that either appends a checkbox under the last question or adds a synthetic
+final step (`CONSENT_STEP_ID` in `FormRenderer.jsx`). It arrives in the
+submission as `_consent: true`. A `consent` *field* type is still rendered for
+backwards compatibility with forms built before this moved.
 
 ### Integration Engine (`models/integrations.js`)
-Handles all outbound data flows:
-- **Webhook**: POST/PUT with optional HMAC-SHA256 signing
-- **Email**: SMTP with HTML-formatted submission table
-- **Google Sheets (Simple)**: Via Apps Script URL
-- **Google Sheets (Service Account)**: Via JSON key, auto-creates headers
-Each integration has an enabled flag and test endpoint.
+Handles all outbound data flows via `runIntegration()`'s switch on
+`integration.type`:
+- **`webhook`**: POST/PUT with optional HMAC-SHA256 signing in `X-OpenFlow-Signature`. ⚠️ Known bug: the digest is computed over `{formId, formTitle, data, timestamp: Date.now()}` while the body sent is `{event, formId, formTitle, data, timestamp: <ISO>}`, so receivers can never verify it. Sign the exact bytes being sent when fixing — and treat it as a breaking change for anyone who worked around it.
+- **`email`**: SMTP with HTML-formatted submission table (values HTML-escaped)
+- **`google_sheets`**: Both Sheets variants share this type and branch on `config.mode` — `apps_script` (URL only) or `service_account` (JSON key, auto-creates headers). The UI's `google_sheets_sa` option is mapped to `google_sheets` before saving.
+- **`google_ads_conversion`**: Offline conversion upload via the Data Manager API; only runs for submissions carrying a `gclid`/`gbraid`/`wbraid`
+
+Each integration has an enabled flag and a test endpoint
+(`POST /api/integrations/:formId/:id/test`). Google Ads is special-cased there:
+its test only validates OAuth credentials via `testGoogleAdsCredentials()`
+instead of uploading a fake conversion. Deliveries go through
+`models/deliveryQueue.js`, which persists an `integration_deliveries` row per
+attempt and retries with backoff before marking it dead.
 
 ### Analytics
-Tracks per-form and global stats: views, starts, completions, conversion rates, step drop-off. Data stored in `analytics` table.
+Tracks per-form and global stats: views, starts, completions, conversion rates,
+step drop-off. Data stored in the `analytics_events` table.
 
 ## Testing
 
@@ -111,7 +149,9 @@ npm test -- auth.test.js
 npm test -- --watch
 ```
 
-Tests cover: authentication, authorization, rate limiting, field validation.
+Tests live in `backend/tests/` and cover: authentication, authorization, API
+tokens, rate limiting, form CRUD, submission validation, slug rules, subdomain
+rules, and backup/restore. There is no frontend test suite.
 
 ## Version Management
 
@@ -120,8 +160,13 @@ Tests cover: authentication, authorization, rate limiting, field validation.
 Version files to update:
 1. **README.md** — Update badge: `# 🌊 OpenFlow v0.X.X`
 2. **CHANGELOG.md** — Add new entry with date and changes
-3. **backend/package.json** — Update `version` field
-4. **frontend/package.json** — Update `version` field
+3. **backend/package.json** + **backend/package-lock.json** — Update `version` (twice in the lockfile: the root and the `""` package entry)
+4. **frontend/package.json** + **frontend/package-lock.json** — Same
+5. **CLAUDE.md** — Update "Current Version" at the top of this file
+
+Nothing else needs touching: the admin sidebar reads the version from
+`frontend/package.json` and `GET /api/` reads it from `backend/package.json`,
+so neither can go stale. The WordPress plugin is versioned separately.
 
 **Version Format**: Semantic versioning (e.g., 0.7.4)
 - Patch (0.7.4 → 0.7.5): Bug fixes
@@ -130,20 +175,27 @@ Version files to update:
 
 ## Database Schema
 
-Key tables:
-- `forms` — Form metadata (title, slug, published, theme, integrations config)
-- `fields` — Form steps/fields (type, label, options, conditional logic)
-- `submissions` — User responses (per-form submissions with data JSON)
-- `submissions_events` — Analytics events (views, starts, completions, step tracking)
-- `integrations` — Integration configs per form (webhook URL, email SMTP, Google Sheets)
-- `users` — Admin users (email, hashed password, role)
+Defined in one `CREATE TABLE IF NOT EXISTS` block plus additive `ALTER TABLE`
+migrations in `models/db.js`:
+
+- `users` — Admin/editor users (email, hashed password, role)
+- `forms` — Everything about a form: `steps`, `end_screen`, `theme` (JSON text columns), `slug`, `gtm_id`, `published`. Steps are **not** a separate table.
+- `submissions` — User responses (`data` + `metadata` JSON, keyed by field id)
+- `integrations` — Integration configs per form (`type`, `enabled`, `config` JSON)
+- `analytics_events` — Analytics events (view, start, step, complete) with `session_id`, `step_index`, `step_id`
+- `integration_deliveries` — One row per delivery attempt (status, attempts, `next_attempt_at`, `last_error`) backing retries and dead letters
+- `api_tokens` — Read-only API tokens (SHA-256 `token_hash`, `token_prefix`, `last_used_at`)
+- `slug_history` — Old slugs of renamed forms, so previously shared links keep resolving
+- `site_settings` — Global key/value settings (currently just `branding`)
 
 ## API Structure
 
 - **Public** (`/api/public/`): No auth required. Load form, submit response, track analytics.
-- **Admin** (`/api/forms`, `/api/submissions`, `/api/auth`): JWT auth required.
-- **Integrations** (`/api/integrations`): Test, create, update, delete integrations.
+- **Admin** (`/api/forms`, `/api/submissions`, `/api/auth`): JWT auth required (`router.use(authMiddleware)`).
+- **Integrations** (`/api/integrations`): Test, create, update, delete integrations; list and retry deliveries.
 - **Analytics** (`/api/analytics`): Get funnel and trend data.
+- **Settings** (`/api/settings`): `GET` is public (branding + `primaryHost` are needed by the login screen and form editor); `PUT /:key` is admin-only and restricted to an allowlist of keys.
+- **Admin-only** (`/api/admin/`): Backup, restore, and scheduled-backup listing. The whole router is behind `authMiddleware, requireAdmin`, and it is blocked outright on per-form subdomains.
 
 ### External consumer: lodgely (lead intake hub)
 
@@ -177,15 +229,17 @@ managed in the UI under **Settings → API Tokens**.
 ## Common Tasks
 
 ### Add a New Field Type
-1. Update `backend/src/models/db.js` — Add validation logic
-2. Update `frontend/src/components/FormRenderer.jsx` — Render the input
-3. Update form schema/types if needed
-4. Test in FormEditor and FormView
+1. Add an entry to `FIELD_TYPES` in `frontend/src/pages/FormEditor.jsx` (value, label, icon, smart defaults) plus any type-specific config UI
+2. Add a renderer + client-side validation in `frontend/src/components/FormRenderer.jsx` (`INPUTS` map and `validateField`), and add it to `AUTO_ADVANCE_FIELDS` if it should advance on click
+3. Add respondent-facing strings to `frontend/src/locales.js` for every language
+4. If the server needs to enforce more than "required and non-empty", extend the validation loop in `backend/src/routes/public.js` (`POST /form/:slug/submit`)
+5. Test in FormEditor, FormView and EmbedView
 
 ### Add a New Integration
-1. Add integration type in `backend/src/models/integrations.js` (handle `test()` and `execute()`)
-2. Update `frontend/src/components/IntegrationsPanel.jsx` — Add config form
-3. Add validation in backend routes
+1. Add a `case` to `runIntegration()` in `backend/src/models/integrations.js` and a `run<Name>()` that **throws** on failure, so the delivery queue can retry it
+2. Add the type to `INTEGRATION_TYPES` and a config form in `frontend/src/components/IntegrationsPanel.jsx`
+3. If the integration fetches a user-supplied URL, run it through `utils/ssrf.js#assertSafeUrl`
+4. Special-case the test path in `backend/src/routes/integrations.js` if a synthetic submission can't safely be sent for real
 
 ### Deploy
 ```bash
@@ -202,17 +256,20 @@ docker compose up -d --build
 
 ## Important Notes
 
-- **SQLite**: All data is in the SQLite database. The Docker volume `db-data` persists data across restarts.
-- **Rate Limiting**: In-memory rate limiter in `models/rateLimit.js` (no external Redis).
+- **SQLite**: All data is in the SQLite database. The Docker volume `db-data` persists data across restarts; scheduled backups go to the separate `./backups` bind mount so a lost `db-data` volume doesn't take them with it.
+- **Rate Limiting**: In-memory rate limiter in `models/rateLimit.js` (no external Redis). Resets on restart.
 - **HMAC Signing**: Webhooks can be signed with a shared secret for security.
-- **Conditional Logic**: Stored as rules array in field config. Evaluated client-side during form render.
-- **Form Slugs**: Unique URL identifier for public form access (e.g., `/embed/my-form-slug`).
+- **Conditional Logic**: Stored as rules array in field config. Evaluated client-side during form render — the server does not re-check visibility, only that required fields are non-empty.
+- **Form Slugs**: Unique URL identifier for public form access (`/f/<slug>` and `/embed/<slug>`). Renaming a slug archives the old one in `slug_history` so old links still resolve.
 - **Multi-User**: Admin can invite users and assign roles. Role-based access control in `middleware/auth.js`.
+- **Secrets**: `JWT_SECRET` is auto-generated and persisted next to the DB when unset; there is no hardcoded fallback. Set it explicitly in production.
+- **Untrusted input into HTML**: GTM ids, custom CSS and emailed field values all pass through validation/sanitization (`validateGtmId`, `utils/sanitizeCss.js`, `escapeHtmlAttr`). Keep it that way when touching those paths.
 
 ## Conventions
 
-- **Form IDs**: UUIDs
-- **Field IDs**: nanoid (short unique strings)
+- **Form IDs / submission IDs / user IDs**: UUID v4
+- **Form slugs**: 8-char nanoid over `[a-z0-9]`, editable afterwards
+- **Field IDs**: generated in the editor as `field_<timestamp>` (`group_…` for combined steps, `custom_…` for address sub-fields). They are opaque — never parse them.
 - **Naming**: camelCase in JavaScript, snake_case in SQL/database
 - **Colors**: Hex format (e.g., `#FF5733`)
-- **Timestamps**: ISO 8601 format in database
+- **Timestamps**: SQLite `datetime('now')` (UTC, `YYYY-MM-DD HH:MM:SS`) for row defaults; submission `metadata.submittedAt` is a full ISO 8601 string

--- a/README.md
+++ b/README.md
@@ -1,29 +1,35 @@
-# 🌊 OpenFlow v0.25.0
+# 🌊 OpenFlow v0.25.1
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents
 
-[Features](#-features) · [Quick Start](#-quick-start) · [Updating](#-updating) · [Configuration](#️-configuration) · [Architecture](#️-architecture) · [Field Types](#-field-types) · [Integrations](#-integrations) · [Analytics](#-analytics) · [GTM Events](#️-gtm-events) · [Embedding](#-embedding) ([iFrame](#simple-iframe) · [Auto-Resize](#iframe-with-auto-resize) · [WordPress](#wordpress) · [URL Slug](#custom-url-slug) · [Subdomains](#custom-subdomains)) · [API Endpoints](#-api-endpoints) · [Development](#‍-development) · [Roadmap](#️-roadmap) · [License](#-license)
+[Features](#-features) · [Quick Start](#-quick-start) · [Updating](#-updating) · [Configuration](#️-configuration) · [Architecture](#️-architecture) · [Field Types](#-field-types) · [Integrations](#-integrations) · [Analytics](#-analytics) · [GTM Events](#️-gtm-events) ([Cookie Banner](#-cookie-consent-banner)) · [Embedding](#-embedding) ([iFrame](#simple-iframe) · [Auto-Resize](#iframe-with-auto-resize) · [WordPress](#wordpress) · [URL Slug](#custom-url-slug) · [Subdomains](#custom-subdomains)) · [API Endpoints](#-api-endpoints) · [Development](#‍-development) · [Roadmap](#️-roadmap) · [License](#-license)
 
 ## ✨ Features
 
 ### 🎯 Form Builder
 - **Multi-Step Forms** — Typeform-style one-question-at-a-time experience with smooth animations
-- **15 Field Types** — Short Text, Long Text, Number, Date, Single Choice, Multiple Choice, Yes/No, Rating, Image/Icon Select, File Upload, Email, Phone, Website URL, Address, Consent/GDPR
+- **14 Field Types** — Short Text, Long Text, Number, Date, Single Choice, Multiple Choice, Yes/No, Rating, Image/Icon Select, File Upload, Email, Phone, Website URL, Address
 - **Number Stepper** — Large +/− buttons with a configurable step size and an optional prefilled start value, for quantity questions where 0 or 1 is an unlikely answer
 - **Inline Date Picker** — An always-visible calendar per date step, set to either a single day or a date range (from – to), with selectable-window limits and localized month/weekday names
 - **Conditional Logic** — Show/hide steps based on previous answers (equals, contains, is set, etc.)
+- **Combined Steps** — Merge two adjacent questions onto one screen (e.g. email + phone), optionally requiring just one of them to be answered
+- **Flat-Rate Pricing Filter** — On a choice step, hide budget options that can't cover a rate × quantity answered earlier, so nobody picks an impossible budget
 - **Smart Defaults** — Selecting a field type auto-fills question, label, and placeholder
 - **Visual Editor** — Collapsible question cards, reorder, visual field type picker with icons
 - **Emoji/Icon Picker** — Built-in category-based emoji selector for Image/Icon Select fields
 - **Landing Page Mode** — Add logo, headline, and subline on top of the form
 - **Footer Links** — Add up to 3 links (Privacy Policy, Imprint, Terms) below the form
-- **Theme Customization** — Colors, custom CSS, animated backgrounds, and branding per form
-- **Animated Backgrounds** — 4 stylish CSS motion presets (Waves, Bubbles, Aurora, Geometric) with 2-color support
+- **End Screen** — Custom thank-you title and message, plus an optional redirect URL that can open automatically on submit (breaking out of the iframe when embedded)
+- **Theme Customization** — Colors, custom CSS, animated backgrounds, and branding per form, with a live preview in the Design tab
+- **Animated Backgrounds** — 5 stylish CSS motion presets (Waves, Bubbles, Aurora, Particles, Flow) with 2-color support
 - **Configurable Button Position** — Place the "Next" button in the footer bar or inline below the input field
+- **Editable Button Labels** — Override the built-in "Next" / "Submit" wording per form
+- **Form Language (EN / DE)** — Sets the language of every built-in string shown to respondents, including error messages and calendar month/weekday names
 - **Enter Key Hint** — Optional "press Enter" keyboard shortcut hint next to the Next button
 - **GDPR-Ready** — Consent under the last question or as its own final step, agreed to by a deliberate press of Enter or a click (form-level toggle)
 - **File Uploads** — Drag & drop with configurable file types and size limits
+- **Duplicate a Form** — One-click copy of a form's questions, theme and integrations, created as a draft with copied integrations disabled
 
 
 <img width="1017" height="672" alt="grafik" src="https://github.com/user-attachments/assets/1265603a-4602-44e6-97b0-15c77afb9456" />
@@ -47,16 +53,18 @@
 
 ### 🔌 Embedding & Tracking
 - **iframe Embed** — Drop forms into any landing page (with auto-resize)
-- **Editable URL Slug** — Rename a form's URL anytime (`/f/spring-launch` instead of the auto-generated 8-char code); old links keep working via 301-style redirect
+- **Editable URL Slug** — Rename a form's URL anytime (`/f/spring-launch` instead of the auto-generated 8-char code); old links keep working, and the browser is rewritten to the current URL
 - **Custom Subdomain** — Host each form on its own subdomain of a domain you control (e.g. `acme.forms.example.com`), backed by a single wildcard TLS cert
 - **🏷️ GTM Integration** — Google Tag Manager per form, with step and submit events
+- **🍪 Cookie Consent Banner** — Optional banner shown *before* GTM loads, so tracking only starts once the visitor accepts
 - **WordPress Plugin** — Shortcode `[openflow]`, WPBakery element, and Gutenberg block
 
 ### 🛠️ Infrastructure
-- **🐳 Docker** — One command to start )
+- **🐳 Docker** — One command to start
 - **SQLite** — Zero-config database, no external DB needed
 - **🛡️ Rate Limiting** — Built-in in-memory spam protection
 - **👥 Multi-User** — Admin can invite users, assign roles (admin/user)
+- **🏷️ White-Label Branding** — Admins can swap or hide the vendor logo in the admin sidebar (**Settings → Branding**)
 - **🔑 API Tokens** — Read-only tokens for programmatic API access (e.g. the lodgely connector); created under Settings, hashed at rest, revocable anytime
 - **💾 Backup & Restore** — Admins can download a full JSON snapshot of the database and restore it later; older backups are auto-migrated to the current format on restore
 - **⏰ Scheduled Backups** — A background job writes a rotating backup on an interval to a separate volume, so recovery doesn't depend on someone remembering to click "Download"
@@ -80,6 +88,8 @@ The app runs on `http://localhost:3000`.
 **🔑 Default Login:**
 - Email: `admin@openflow.local`
 - Password: `admin123`
+
+> ⚠️ Those are the fallbacks baked into `docker-compose.yml`. **Change the password after the first login**, or set `ADMIN_EMAIL`/`ADMIN_PASSWORD` in `.env` before the first start. If you run the backend without those compose defaults and leave `ADMIN_PASSWORD` unset, OpenFlow generates a random one-time admin password and prints it to the server log instead.
 
 ---
 
@@ -106,15 +116,19 @@ Environment variables (in `.env` or docker-compose):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `JWT_SECRET` | `change-me-in-production` | 🔐 JWT Signing Key |
+| `JWT_SECRET` | `change-me-in-production` (from `docker-compose.yml`) | 🔐 JWT signing key. Without the compose default, a random secret is generated and persisted next to the database — set this explicitly in production so sessions survive a volume reset |
 | `ADMIN_EMAIL` | `admin@openflow.local` | 👤 Admin email |
-| `ADMIN_PASSWORD` | `admin123` | 🔑 Admin password (only on first start) |
+| `ADMIN_PASSWORD` | `admin123` (from `docker-compose.yml`) | 🔑 Admin password (only on first start). Without the compose default, a random one is generated and printed to the log once |
 | `DB_PATH` | `/app/data/openflow.db` | 💾 SQLite database path |
 | `PORT` | `3000` | 🌐 Server port |
+| `CORS_ORIGINS` | *(empty)* | 🌍 Comma-separated extra origins allowed to call the API. Same-origin requests are always allowed, so this is only needed when the admin UI is served from a different host than the API |
+| `OPENFLOW_PRIMARY_HOST` | *(empty)* | 🌐 Apex host for [custom subdomains](#custom-subdomains). Also implicitly allowed as a CORS origin |
 | `BACKUP_ENABLED` | `true` | ⏰ Set to `false` to disable the scheduled backup job |
-| `BACKUP_DIR` | next to `DB_PATH` | 📁 Where scheduled backups are written (point at a separate volume for real off-box protection) |
+| `BACKUP_DIR` | `/app/backups` (from `docker-compose.yml`; otherwise a `backups/` folder next to `DB_PATH`) | 📁 Where scheduled backups are written (point at a separate volume for real off-box protection) |
 | `BACKUP_INTERVAL_HOURS` | `24` | ⏱️ How often to write a scheduled backup |
 | `BACKUP_RETENTION_COUNT` | `14` | 🗑️ How many scheduled backups to keep before pruning the oldest |
+
+> 💾 `docker-compose.yml` bind-mounts `./backups` on the host into the container, deliberately **outside** the `db-data` volume — so wiping or losing that volume doesn't take the backups with it. Copy `./backups` off the host regularly for real disaster recovery.
 
 ---
 
@@ -122,23 +136,32 @@ Environment variables (in `.env` or docker-compose):
 
 ```
 openflow/
-├── backend/                # 🟢 Express API + SQLite
+├── backend/                        # 🟢 Express API + SQLite (also serves the built frontend)
+│   ├── src/
+│   │   ├── index.js                # Server entry point, CORS, SPA fallback
+│   │   ├── models/                 # DB schema, integrations engine, delivery queue,
+│   │   │                           #   backups, API tokens, rate limiting
+│   │   ├── middleware/             # JWT + API-token auth, per-form subdomain routing
+│   │   ├── routes/                 # auth, forms, submissions, public, integrations,
+│   │   │                           #   analytics, settings, admin
+│   │   └── utils/                  # slug/subdomain rules, CSS sanitizer, SSRF guard
+│   └── tests/                      # Jest + supertest
+├── frontend/                       # ⚛️ React (Vite)
 │   └── src/
-│       ├── index.js        # Server entry point
-│       ├── models/         # DB, Rate Limiting, Integrations engine
-│       ├── middleware/      # JWT Auth
-│       └── routes/         # API endpoints
-├── frontend/               # ⚛️ React (Vite)
-│   └── src/
-│       ├── components/     # FormRenderer, IntegrationsPanel
-│       ├── pages/          # Admin + Public Views
-│       └── styles/         # CSS
-├── wordpress-plugin/       # 🔌 WordPress integration
+│       ├── main.jsx                # /f/:slug, /embed/:slug, and the admin SPA
+│       ├── components/             # FormRenderer, IntegrationsPanel, shared admin UI
+│       ├── pages/                  # Admin pages + public form/embed views
+│       ├── locales.js              # Respondent-facing strings (EN / DE)
+│       └── styles/                 # CSS
+├── wordpress-plugin/               # 🔌 WordPress integration
 │   └── openflow/
-│       ├── openflow.php    # Shortcode + WPBakery + Gutenberg
-│       └── block.js        # Gutenberg block editor
-├── Dockerfile
-└── docker-compose.yml
+│       ├── openflow.php            # Shortcode + WPBakery + Gutenberg
+│       └── block.js                # Gutenberg block editor
+├── docs/integrations/              # 📚 Per-integration setup walkthroughs
+├── Dockerfile                      # Multi-stage: builds the frontend into the backend image
+├── docker-compose.yml
+├── docker-compose.subdomains.yml   # Optional Caddy overlay for custom subdomains
+└── Caddyfile
 ```
 
 ---
@@ -167,8 +190,11 @@ openflow/
 | 📧 Email Address | Email with validation | |
 | 📞 Phone Number | Phone number input | |
 | 🌐 Website URL | URL with validation | |
-| 🏠 Address | Composite address field | Street, Postal Code, City, Country |
-| 🔒 Consent / GDPR | Checkbox with configurable legal text | |
+| 🏠 Address | Composite address field (sub-field labels are editable) | Street, Postal Code, City, Country |
+
+> 🔒 **Consent / GDPR is not a field type** — it's a per-form setting in the **GTM / GDPR** tab. Switch it on and the consent checkbox with your legal text is added either under the last question or as its own final step; it arrives in the submission as `_consent`.
+
+Any two adjacent questions can be **combined** into a single step (e.g. email + phone side by side) via the **Combine** buttons in the editor, and split apart again at any time.
 
 ---
 
@@ -179,8 +205,11 @@ Configure integrations per form in the **Integrations** tab of the form editor.
 ### 🔗 Webhook
 Send submission data to any URL on each submission.
 - Configurable HTTP method (POST/PUT)
-- Optional HMAC-SHA256 signing with shared secret
-- Payload includes `formId`, `formTitle`, `data`, `timestamp`
+- JSON payload: `event` (always `"submission"`), `formId`, `formTitle`, `data` (keyed by field id), `timestamp` (ISO 8601)
+- Optional HMAC-SHA256 signing with a shared secret, sent as an `X-OpenFlow-Signature` header
+- The target URL is checked against private/internal address ranges before the request is made, and redirects are not followed
+
+> ⚠️ **Known issue:** the `X-OpenFlow-Signature` digest is currently computed over a slightly different object than the one actually sent (it omits `event` and uses a millisecond `timestamp`), so signature verification on the receiving end will not match. Leave the secret blank until this is fixed, or verify by shared-secret transport instead.
 
 ### 📧 Email Notification
 Receive an email with a formatted HTML table of each submission.
@@ -263,6 +292,14 @@ OpenFlow automatically pushes events to the Google Tag Manager dataLayer:
 |-------|---------|------|
 | `openflow_step` | Each step change | `formId`, `stepIndex`, `stepId` |
 | `openflow_submit` | Form submitted | `formId`, `formTitle` |
+
+Set the container ID per form under **GTM / GDPR → GTM Container ID** (it must look like `GTM-XXXXXXX`).
+
+### 🍪 Cookie consent banner
+
+Optionally, a consent banner can be shown **before** the GTM container is loaded — GTM only fires once the visitor accepts, and the choice is remembered in their browser so the banner doesn't reappear. Enable it under **GTM / GDPR → Cookie / Tracking Consent Banner**; the message and both button labels are editable. A GTM container ID must be set first.
+
+The same consent gates the ad click IDs (`gclid`/`gbraid`/`wbraid`) that the [Google Ads integration](#-google-ads-server-side-conversion) relies on.
 
 ---
 
@@ -410,16 +447,23 @@ A form's `/f/<slug>` and `/embed/<slug>` URLs on the primary host always keep wo
 - `POST /api/public/form/:slug/submit` — Submit response
 - `POST /api/public/track` — Track analytics event
 
+### Auth
+- `POST /api/auth/login` — Log in (sets a `token` httpOnly cookie and returns the JWT)
+- `POST /api/auth/logout` — Clear the session cookie
+- `GET /api/auth/me` — Current user
+
 ### Admin (auth required)
-- `POST /api/auth/login` — Log in
 - `GET /api/forms` — List all forms
+- `GET /api/forms/:id` — Get one form (including its `steps`)
 - `POST /api/forms` — Create form
+- `POST /api/forms/:id/clone` — Duplicate a form (draft copy, integrations disabled)
 - `PUT /api/forms/:id` — Update form
 - `DELETE /api/forms/:id` — Delete form
-- `GET /api/submissions/:formId` — Get submissions (paginated)
+- `GET /api/submissions/:formId` — Get submissions (paginated, newest first)
 - `GET /api/submissions/:formId/export` — CSV export
-- `GET /api/admin/backups` — List backups written by the scheduler
-- `GET /api/admin/backups/:filename` — Download a specific scheduled backup
+- `DELETE /api/submissions/:formId/:submissionId` — Delete a submission
+- `GET /api/settings` — Read global settings (public) — branding and the configured primary host
+- `PUT /api/settings/:key` — Update a global setting (admin only)
 
 ### Integrations (auth required)
 - `GET /api/integrations/:formId` — List integrations
@@ -440,6 +484,20 @@ A form's `/f/<slug>` and `/embed/<slug>` URLs on the primary host always keep wo
 - `PUT /api/auth/users/:id` — Update user role/password
 - `DELETE /api/auth/users/:id` — Delete user
 
+### API Tokens (session auth only — a token can never manage tokens)
+- `GET /api/auth/tokens` — List your tokens (prefix + last used, never the secret)
+- `POST /api/auth/tokens` — Mint a token (the plaintext `ofw_…` value is returned **once**)
+- `DELETE /api/auth/tokens/:id` — Revoke a token
+
+### Backup & Restore (admin only)
+- `GET /api/admin/backup/info` — Summary of current DB contents and backup format version
+- `GET /api/admin/backup` — Download a full JSON backup
+- `POST /api/admin/restore` — Restore from a JSON backup
+- `GET /api/admin/backups` — List backups written by the scheduler
+- `GET /api/admin/backups/:filename` — Download a specific scheduled backup
+
+> 🔑 Read-only API tokens (`Authorization: Bearer ofw_…`) may call any **GET/HEAD** endpoint above on behalf of their owner. Every other method is rejected.
+
 ---
 
 ## 🧑‍💻 Development
@@ -454,6 +512,12 @@ cd frontend && npm install && npm run dev
 
 Frontend dev server: `http://localhost:5173` (proxies API to port 3000)
 
+Run the backend test suite (Jest + supertest):
+
+```bash
+cd backend && npm test
+```
+
 ---
 
 ## 🗺️ Roadmap
@@ -462,7 +526,8 @@ Frontend dev server: `http://localhost:5173` (proxies API to port 3000)
 - ✅ **Phase 2**: Webhook, email notifications, Google Sheets integration
 - ✅ **Phase 3**: Conditional logic, file uploads, custom CSS per form, multi-user support, landing page header/footer
 - ✅ **Phase 4**: Analytics dashboard, simplified Google Sheets, dark mode, delete protection for live forms
-- 🔜 **Phase 5**: A/B testing, custom domain support, form templates
+- ✅ **Phase 5**: Editable slugs and per-form subdomains, backup & restore, read-only API tokens, retrying integration deliveries, server-side Google Ads conversions
+- 🔜 **Phase 6**: A/B testing, form templates, more languages
 
 ---
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wordpress-plugin/openflow/openflow.php
+++ b/wordpress-plugin/openflow/openflow.php
@@ -1,11 +1,12 @@
 <?php
 /**
  * Plugin Name: OpenFlow Form Embed
- * Plugin URI: https://github.com/your-org/openflow
+ * Plugin URI: https://github.com/vidual-labs/openflow
  * Description: Embed OpenFlow lead generation forms via shortcode or WPBakery element. Connect to your self-hosted OpenFlow instance.
  * Version: 1.0.0
  * Author: OpenFlow
- * License: MIT
+ * License: GPL-3.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: openflow
  */
 

--- a/wordpress-plugin/openflow/readme.txt
+++ b/wordpress-plugin/openflow/readme.txt
@@ -5,7 +5,8 @@ Requires at least: 5.0
 Tested up to: 6.7
 Stable tag: 1.0.0
 Requires PHP: 7.4
-License: MIT
+License: GPLv3 or later
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 Embed OpenFlow lead generation forms in WordPress via shortcode, WPBakery element, or Gutenberg block.
 


### PR DESCRIPTION
A full review of README.md, CHANGELOG.md and CLAUDE.md against the actual code. Docs only — no behaviour changes.

## CLAUDE.md

This had drifted the furthest. It was pinned at **0.14.0**, eleven releases behind, and described a database that doesn't exist:

- a `fields` table for form steps — steps are a JSON column on `forms`
- a `submissions_events` table for analytics — it's `analytics_events`
- five tables added since were missing entirely: `analytics_events`, `integration_deliveries`, `api_tokens`, `slug_history`, `site_settings`

Also corrected:

- **Infrastructure** described "backend and frontend services"; the compose file has run a single `app` service since the frontend was folded into the backend image by the multi-stage Dockerfile
- **"Add a New Field Type"** pointed at `models/db.js` for validation, which has never held any. Field types are defined in `FormEditor.jsx`, validated in `FormRenderer.jsx`, and the server's only check is the required-field loop in `routes/public.js`
- **"Field IDs: nanoid"** — nanoid generates form *slugs* (8 chars); field ids are `field_<timestamp>`
- **Timestamps: ISO 8601** — row defaults are SQLite `datetime('now')`; only `metadata.submittedAt` is ISO 8601
- Added the delivery queue, backups, API tokens, subdomain middleware and `utils/` helpers to the file map, plus the Google Ads integration and the `google_sheets` / `google_sheets_sa` type mapping

## README.md

**Wrong:**

- **"15 Field Types" including Consent/GDPR** — the picker has 14. Consent has been a form-level setting since 0.23.0, not something the builder can insert. Documented as what it is, with a note that it arrives as `_consent`.
- **"4 animated backgrounds (Waves, Bubbles, Aurora, Geometric)"** — there are five, and none is Geometric: Waves, Bubbles, Aurora, Particles, Flow
- **"old links keep working via 301-style redirect"** — there is no HTTP redirect; the API serves the form under its canonical slug and the client rewrites the URL
- **`JWT_SECRET` / `ADMIN_PASSWORD` defaults** were the `docker-compose.yml` fallbacks presented as the app's own. Since 0.16.0 the app generates both when unset. Both are now labelled by origin, with the same note in Quick Start so `admin123` doesn't read as permanent.
- A stray `)` in the Docker feature bullet

**Missing:** features shipped between 0.11.0 and 0.21.0 — combined steps, the flat-rate pricing filter, form duplication, the end-screen auto-redirect, the form language setting, editable Next/Submit labels, the live theme preview, white-label branding, and the cookie consent banner (now a section under GTM Events, since it also gates the ad click IDs the Google Ads integration depends on). Config table was missing `CORS_ORIGINS` and `OPENFLOW_PRIMARY_HOST`. The API reference covered about half the surface — added auth (`logout`, `me`), form clone, submission delete, settings, API tokens and backup/restore.

**Refreshed:** the architecture tree (omitted `tests/`, `utils/`, `docs/`, the Caddy overlay, and that the Dockerfile builds the frontend into the backend image) and the roadmap, which still listed "custom domain support" as upcoming — it shipped in 0.11.0 as per-form subdomains.

## ⚠️ Webhook HMAC signing is broken — needs a code fix

Verifying the documented webhook payload turned up a real defect in `models/integrations.js`. The signature is computed over one object and a different one is sent:

```js
const body    = JSON.stringify({ formId, formTitle, data, timestamp: Date.now() });        // signed
const payload = { event: 'submission', formId, formTitle, data, timestamp: new Date().toISOString() };  // sent
```

The digest differs in two ways (`event` is absent, `timestamp` is a number rather than an ISO string), so a receiver verifying `X-OpenFlow-Signature` against the bytes it received can never get a match.

Fixing it is a behaviour change and out of scope for a docs PR, so signing is untouched here — the README carries a warning and CLAUDE.md notes it for whoever picks it up. Worth treating as breaking for anyone who has worked around it.

## WordPress plugin

`openflow.php` and `readme.txt` both declared **MIT** inside a GPL-3.0 repository. Both now declare GPL-3.0 with a license URI, matching the root `LICENSE` and the README. `Plugin URI` also pointed at the `your-org` placeholder. **Flagging the licence line explicitly** in case the MIT declaration was deliberate — revert that hunk if so.

## Verification

- `php -l wordpress-plugin/openflow/openflow.php` — clean
- `npx jest --runInBand` — 109/114 pass. The 5 failures (4 in `auth.test.js` user deletion, 1 in `validation.test.js` analytics events) are **pre-existing**: identical results on a stashed, clean tree.
- Separately noticed: `tests/setup.js` deletes `test.db` but not its `-wal`/`-shm` sidecars, so once a run leaves them behind every later run fails with `disk I/O error` until they're removed by hand. Not touched here.

Version bumped to **0.25.1** across README badge, CHANGELOG, both `package.json` files, both lockfiles and CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY2UjFVuGaAnjASNNgNbEC)_