### PR TITLE
Link email/phone values in lead-notification emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.25.2] - 2026-08-12
+
+### Changed
+- **Email notifications now link phone and email answers** — a submission's `email`-type and `phone`-type field values in the notification email table are wrapped in `mailto:`/`tel:` links, so a client reading a lead notification can call or email the lead with one tap instead of copying the value out first. Phone numbers keep their original display text; the `tel:` href strips everything but digits and a leading `+`. Other field types are unaffected.
+
 ## [0.25.1] - 2026-08-09
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.25.3] - 2026-08-12
+
+### Changed
+- **Made the new mailto/tel links in email notifications optional** — some setups route leads through lodgely for tracking, and a one-tap "call now" link that never touches lodgely means the lead can be worked without ever being marked there. The email integration gets its own **"Make email and phone answers clickable"** checkbox, independent of the lodgely link, so this can be turned off per integration where that routing matters. Defaults to on.
+
 ## [0.25.2] - 2026-08-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets, Google Ads), analytics, and a WordPress plugin.
 
-**Current Version**: 0.25.2 (see version badge in README.md and CHANGELOG.md)
+**Current Version**: 0.25.3 (see version badge in README.md and CHANGELOG.md)
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets, Google Ads), analytics, and a WordPress plugin.
 
-**Current Version**: 0.25.1 (see version badge in README.md and CHANGELOG.md)
+**Current Version**: 0.25.2 (see version badge in README.md and CHANGELOG.md)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.25.1
+# 🌊 OpenFlow v0.25.2
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.25.2
+# 🌊 OpenFlow v0.25.3
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -113,11 +113,23 @@ async function runEmail(config, formId, formTitle, data, steps) {
 
   // Build a nice HTML table from submission data (one row per field, groups expanded)
   const rows = flattenFields(steps).map(field => {
-    let val = data[field.id];
+    const rawVal = data[field.id];
+    let val = rawVal;
     if (val === undefined || val === null) val = '-';
     if (typeof val === 'object') val = JSON.stringify(val);
     if (Array.isArray(val)) val = val.join(', ');
-    return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:#555;">${escapeHtmlAttr(field.label || field.question || field.id)}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;">${escapeHtmlAttr(val)}</td></tr>`;
+
+    let valueHtml = escapeHtmlAttr(val);
+    if (typeof rawVal === 'string' && rawVal.trim()) {
+      if (field.type === 'email') {
+        valueHtml = `<a href="mailto:${escapeHtmlAttr(rawVal.trim())}">${valueHtml}</a>`;
+      } else if (field.type === 'phone') {
+        const telNumber = rawVal.replace(/[^\d+]/g, '');
+        if (telNumber) valueHtml = `<a href="tel:${escapeHtmlAttr(telNumber)}">${valueHtml}</a>`;
+      }
+    }
+
+    return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee;font-weight:600;color:#555;">${escapeHtmlAttr(field.label || field.question || field.id)}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;">${valueHtml}</td></tr>`;
   }).join('');
 
   const lodgelyLink = lodgely_link_enabled && lodgely_url

--- a/backend/src/models/integrations.js
+++ b/backend/src/models/integrations.js
@@ -99,6 +99,7 @@ function escapeHtmlAttr(str) {
 async function runEmail(config, formId, formTitle, data, steps) {
   const {
     smtp_host, smtp_port = 587, smtp_user, smtp_pass, smtp_secure = false, to, from, subject,
+    contact_links_enabled = true,
     lodgely_link_enabled, lodgely_url, lodgely_button_text,
   } = config;
 
@@ -120,7 +121,7 @@ async function runEmail(config, formId, formTitle, data, steps) {
     if (Array.isArray(val)) val = val.join(', ');
 
     let valueHtml = escapeHtmlAttr(val);
-    if (typeof rawVal === 'string' && rawVal.trim()) {
+    if (contact_links_enabled && typeof rawVal === 'string' && rawVal.trim()) {
       if (field.type === 'email') {
         valueHtml = `<a href="mailto:${escapeHtmlAttr(rawVal.trim())}">${valueHtml}</a>`;
       } else if (field.type === 'phone') {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/IntegrationsPanel.jsx
+++ b/frontend/src/components/IntegrationsPanel.jsx
@@ -59,7 +59,7 @@ export default function IntegrationsPanel({ formId, steps = [] }) {
     const actualType = type === 'google_sheets_sa' ? 'google_sheets' : type;
     const defaults = {
       webhook: { url: '', secret: '', method: 'POST' },
-      email: { smtp_host: '', smtp_port: 587, smtp_user: '', smtp_pass: '', smtp_secure: false, to: '', from: '', subject: '', lodgely_link_enabled: false, lodgely_url: '', lodgely_button_text: '' },
+      email: { smtp_host: '', smtp_port: 587, smtp_user: '', smtp_pass: '', smtp_secure: false, to: '', from: '', subject: '', contact_links_enabled: true, lodgely_link_enabled: false, lodgely_url: '', lodgely_button_text: '' },
       google_sheets: { mode: 'apps_script', apps_script_url: '' },
       google_sheets_sa: { mode: 'service_account', credentials_json: '', spreadsheet_id: '', sheet_name: 'Sheet1' },
       google_ads_conversion: {
@@ -302,6 +302,10 @@ function EmailConfig({ config, onChange }) {
       <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14 }}>
         <input type="checkbox" checked={config.smtp_secure || false} onChange={e => onChange('smtp_secure', e.target.checked)} />
         Use SSL/TLS (port 465)
+      </label>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14, gridColumn: '1 / -1' }}>
+        <input type="checkbox" checked={config.contact_links_enabled !== false} onChange={e => onChange('contact_links_enabled', e.target.checked)} />
+        Make email and phone answers clickable (mailto: / tel: links)
       </label>
       <div style={{ gridColumn: '1 / -1', borderTop: '1px solid var(--border)', marginTop: 8, paddingTop: 12 }}>
         <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14, marginBottom: config.lodgely_link_enabled ? 12 : 0 }}>


### PR DESCRIPTION
## Summary
- Email- and phone-type field values in the email integration's HTML submission table are now wrapped in `mailto:`/`tel:` links, so a client opening a lead-notification email can call or email the lead directly.
- Phone `href`s strip everything but digits and a leading `+`, keeping the original display text; the `mailto:` href uses the trimmed field value. Both go through the existing `escapeHtmlAttr` for HTML-attribute safety, same as the rest of the table. All other field types are unaffected.
- Version bumped 0.25.1 → 0.25.2 (README badge, CHANGELOG, `backend`/`frontend` `package.json` + lockfiles, CLAUDE.md) per repo convention.

## Test plan
- [x] Manually exercised `runEmail()` with a mocked `nodemailer` transport and a form containing `email`, `phone`, and `text` fields — confirmed the generated HTML wraps email/phone values in the expected `mailto:`/`tel:` links, strips punctuation from the `tel:` href while keeping the display text, and leaves other field types (including one with `<script>` in the value) safely escaped and unlinked.
- [x] `cd backend && npm test` — 109/114 passing; the 5 failures (user-deletion permission checks in `auth.test.js`, analytics tracking in `validation.test.js`) are in code paths untouched by this change and reproduce independent of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BksX2bHQveDaKgo8arLy8P)_