### PR TITLE
Accessibility pass on the public form renderer (WCAG 2.1 AA)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,41 @@
-JWT_SECRET=your-secret-key-here
+# Copy this file to .env and fill in real values before deploying to
+# production. Nothing here is required to start the app — if left unset,
+# JWT_SECRET/ENCRYPTION_KEY are auto-generated and persisted next to the
+# database, and ADMIN_PASSWORD is auto-generated and printed once to the
+# container log on first boot. Setting them explicitly just lets you control
+# the values instead of discovering them in `docker compose logs app`.
+
+# --- Secrets (recommended to set explicitly in production) ---
+
+# Signs login sessions (JWTs). If unset, a random one is generated and
+# persisted next to the database — losing it just logs everyone out.
+JWT_SECRET=
+
+# Encrypts integration secrets at rest (SMTP passwords, Google credentials,
+# webhook HMAC secrets) in the database. Must be 64 hex characters (32 bytes),
+# e.g. generate one with: openssl rand -hex 32
+# If unset, a random key is generated and persisted next to the database —
+# but unlike JWT_SECRET, losing this key makes existing encrypted integration
+# config permanently unreadable. Back it up separately from the DB.
+ENCRYPTION_KEY=
+
+# --- Admin account (first boot only) ---
+
 ADMIN_EMAIL=admin@openflow.local
-ADMIN_PASSWORD=admin123
+# Leave unset to get a random one-time password printed to the log instead
+# of a fixed value you have to remember to change.
+ADMIN_PASSWORD=
+
+# --- Backups ---
+
+# BACKUP_ENABLED=true
+# BACKUP_INTERVAL_HOURS=24
+# BACKUP_RETENTION_COUNT=14
+
+# --- CORS (only needed if the admin UI is served from a different host
+# than the API — same-origin requests are always allowed) ---
+
+# CORS_ORIGINS=https://admin.example.com
 
 # --- Custom subdomains (optional) ---
 # When set, the backend serves a single form on each <subdomain>.OPENFLOW_PRIMARY_HOST.
@@ -12,3 +47,4 @@ ADMIN_PASSWORD=admin123
 # provider plugin and token to match the DNS account that owns OPENFLOW_PRIMARY_HOST.
 # CADDY_DNS_PROVIDER=cloudflare
 # CADDY_DNS_TOKEN=your-dns-api-token
+# CADDY_ACME_EMAIL=you@example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.28.0] - 2026-08-12
+
+### Accessibility
+- **WCAG 2.1 AA pass on the public form renderer** (`FormRenderer.jsx`, `FormView.jsx`, `EmbedView.jsx`):
+  - The question heading is now programmatically associated with its field (`aria-labelledby`) instead of being a purely visual label, for both single-question and combined ("group") steps.
+  - Validation errors are announced via `role="alert"` instead of only appearing visually.
+  - Choice-style controls (single/multi-select, yes/no, image-select, star rating) expose their selected state via `aria-pressed`, and star ratings get a descriptive `aria-label` ("3 out of 5 stars").
+  - The progress bar exposes `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` and a localized "Step N of M" label.
+  - The file-upload dropzone is now keyboard-operable (`role="button"`, `tabIndex`, Enter/Space triggers the file picker) — previously it only responded to a mouse click.
+  - The "previous question" nav button, which had no visible text, gets a localized `aria-label`.
+  - `<html lang>` now tracks the form's respondent-facing language (EN/DE) on both `/f/:slug` and `/embed/:slug`, instead of always reporting the admin shell's language.
+  - Address sub-field labels (text/dropdown/radio-group custom fields) are now programmatically linked to their inputs via `htmlFor`/`aria-labelledby` rather than being unassociated sibling text.
+  - The cookie-consent banner and the calendar are given accessible group labels.
+- New locale strings (`previousStep`, `stepProgress`, `starRating`) added to both EN and DE in `locales.js` for the assistive-tech-only labels above.
+
 ## [0.27.1] - 2026-08-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets, Google Ads), analytics, and a WordPress plugin.
 
-**Current Version**: 0.27.1 (see version badge in README.md and CHANGELOG.md)
+**Current Version**: 0.28.0 (see version badge in README.md and CHANGELOG.md)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.27.1
+# 🌊 OpenFlow v0.28.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents
@@ -76,6 +76,7 @@
 - **📊 Structured Logging** — Request, integration-delivery, and backup events are logged as single-line JSON so they can be piped into any log aggregator
 - **🌙 Dark Mode** — Auto/light/dark theme toggle for the admin interface
 - **🛡️ Delete Protection** — Published forms require typing the form name to confirm deletion
+- **♿ Accessible Forms** — Labeled questions, announced errors, keyboard-operable file uploads, and a progress bar and choice controls exposed to assistive tech (WCAG 2.1 AA pass on `/f/:slug` and `/embed/:slug`)
 - **Responsive** — Optimized for mobile and desktop
 
 ---

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.27.1",
+      "version": "0.28.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.27.1",
+      "version": "0.28.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/FormRenderer.jsx
+++ b/frontend/src/components/FormRenderer.jsx
@@ -114,12 +114,13 @@ function GroupInput({ step, answers, setFieldAnswer }) {
       {(step.fields || []).map((field, idx) => {
         const Field = FIELD_TYPES[field.type] || TextInput;
         const display = applyPricingFilter(field, answers);
+        const questionId = `step-question-${field.id}`;
         return (
           <div key={field.id} className="form-group-field" style={idx > 0 ? { marginTop: 24 } : undefined}>
             {field.label && <span className="step-label">{field.label}</span>}
-            {field.question && <h3 className="step-question group-subquestion">{field.question}</h3>}
+            {field.question && <h3 className="step-question group-subquestion" id={questionId}>{field.question}</h3>}
             {field.description && <p className="step-description">{field.description}</p>}
-            <div className="step-field">
+            <div className="step-field" role="group" aria-labelledby={field.question ? questionId : undefined}>
               <Field step={display} value={answers[field.id]} onChange={(v) => setFieldAnswer(field.id, v)} />
             </div>
           </div>
@@ -667,7 +668,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
 
   return (
     <LocaleContext.Provider value={locale}>
-    <div className={`form-renderer ${embedded ? 'embedded' : ''}`} style={themeVars} onKeyDown={handleKeyDown} ref={containerRef}>
+    <div className={`form-renderer ${embedded ? 'embedded' : ''}`} style={themeVars} onKeyDown={handleKeyDown} ref={containerRef} role="form" aria-label={form.title || undefined}>
       {/* Custom CSS */}
       {theme.customCss && <style>{theme.customCss}</style>}
 
@@ -687,7 +688,14 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
         </div>
       )}
 
-      <div className="form-progress">
+      <div
+        className="form-progress"
+        role="progressbar"
+        aria-valuenow={Math.round(progress)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={locale.stepProgress(currentStep + 1, steps.length)}
+      >
         <div className="form-progress-bar" style={{ width: `${progress}%` }} />
       </div>
 
@@ -708,10 +716,10 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
           ) : (
             <>
               {step.label && <span className="step-label">{step.label}</span>}
-              <h2 className="step-question">{step.question}</h2>
+              <h2 className="step-question" id={`step-question-${step.id}`}>{step.question}</h2>
               {step.description && <p className="step-description">{step.description}</p>}
 
-              <div className="step-field">
+              <div className="step-field" role="group" aria-labelledby={`step-question-${step.id}`}>
                 {isConsentStep ? (
                   <ConsentStepInput
                     text={consentText}
@@ -745,7 +753,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
             </>
           )}
 
-          {error && <p className="step-error">{error}</p>}
+          {error && <p className="step-error" role="alert">{error}</p>}
         </div>
       </div>
 
@@ -761,7 +769,7 @@ export default function FormRenderer({ form, onSubmit, embedded = false }) {
       )}
 
       <div className="form-nav">
-        <button className="form-nav-btn" onClick={prev} disabled={currentStep === 0}>
+        <button className="form-nav-btn" onClick={prev} disabled={currentStep === 0} aria-label={locale.previousStep}>
           &#8592;
         </button>
         <span className="form-step-count">{currentStep + 1} / {steps.length}</span>
@@ -972,7 +980,7 @@ function DateInput({ step, value, onChange }) {
   }
 
   return (
-    <div className="form-calendar" onMouseLeave={() => setHovered('')}>
+    <div className="form-calendar" onMouseLeave={() => setHovered('')} role="group" aria-label={isRange ? locale.dateHintRange : locale.dateHintSingle}>
       {/* A bare grid of days doesn't say how many dates it wants — visitors on a range
           step read it as "pick a day" and move on. The step's own description wins if
           the builder wrote one. */}
@@ -1045,7 +1053,7 @@ function SelectInput({ step, value, onChange }) {
         const optValue = typeof opt === 'string' ? opt : (opt.value ?? opt.label);
         const optLabel = typeof opt === 'string' ? opt : opt.label;
         return (
-          <button key={i} className={`form-option ${value === optValue ? 'selected' : ''}`} onClick={() => onChange(optValue)}>
+          <button key={i} className={`form-option ${value === optValue ? 'selected' : ''}`} onClick={() => onChange(optValue)} aria-pressed={value === optValue}>
             {optLabel}
           </button>
         );
@@ -1109,7 +1117,7 @@ function MultiSelectInput({ step, value, onChange }) {
         const optValue = typeof opt === 'string' ? opt : (opt.value ?? opt.label);
         const optLabel = typeof opt === 'string' ? opt : opt.label;
         return (
-          <button key={i} className={`form-option ${chosen.includes(optValue) ? 'selected' : ''}`} onClick={() => toggle(optValue)}>
+          <button key={i} className={`form-option ${chosen.includes(optValue) ? 'selected' : ''}`} onClick={() => toggle(optValue)} aria-pressed={chosen.includes(optValue)}>
             <span className="option-key">{chosen.includes(optValue) ? '✓' : ''}</span>
             {optLabel}
           </button>
@@ -1117,7 +1125,7 @@ function MultiSelectInput({ step, value, onChange }) {
       })}
       {step.allowOther && (
         <>
-          <button className={`form-option ${otherOpen ? 'selected' : ''}`} onClick={toggleOther}>
+          <button className={`form-option ${otherOpen ? 'selected' : ''}`} onClick={toggleOther} aria-pressed={otherOpen}>
             <span className="option-key">{otherOpen ? '✓' : ''}</span>
             {step.otherLabel || locale.otherOption}
           </button>
@@ -1141,10 +1149,10 @@ function YesNoInput({ step, value, onChange }) {
   const locale = useLocale();
   return (
     <div className="form-options form-yesno">
-      <button className={`form-option ${value === 'yes' ? 'selected' : ''}`} onClick={() => onChange('yes')}>
+      <button className={`form-option ${value === 'yes' ? 'selected' : ''}`} onClick={() => onChange('yes')} aria-pressed={value === 'yes'}>
         {locale.yes}
       </button>
-      <button className={`form-option ${value === 'no' ? 'selected' : ''}`} onClick={() => onChange('no')}>
+      <button className={`form-option ${value === 'no' ? 'selected' : ''}`} onClick={() => onChange('no')} aria-pressed={value === 'no'}>
         {locale.no}
       </button>
     </div>
@@ -1152,11 +1160,18 @@ function YesNoInput({ step, value, onChange }) {
 }
 
 function RatingInput({ step, value, onChange }) {
+  const locale = useLocale();
   const max = step.max || 5;
   return (
     <div className="form-rating">
       {Array.from({ length: max }, (_, i) => i + 1).map(n => (
-        <button key={n} className={`rating-star ${value >= n ? 'active' : ''}`} onClick={() => onChange(n)}>
+        <button
+          key={n}
+          className={`rating-star ${value >= n ? 'active' : ''}`}
+          onClick={() => onChange(n)}
+          aria-pressed={value === n}
+          aria-label={locale.starRating(n, max)}
+        >
           {value >= n ? '★' : '☆'}
         </button>
       ))}
@@ -1189,18 +1204,20 @@ function AddressInput({ step, value, onChange }) {
       {step.showCountry !== false && (
         <input className="form-input" type="text" placeholder={al.country || locale.addressCountry} value={data.country || ''} onChange={e => update('country', e.target.value)} />
       )}
-      {customFields.map((field, idx) => (
+      {customFields.map((field, idx) => {
+        const fieldLabelId = `addr-label-${field.id || idx}`;
+        return (
         <div key={field.id || idx} style={{ marginTop: 12 }}>
           {field.type === 'text' && (
             <>
-              <label style={{ display: 'block', fontSize: 13, marginBottom: 4, color: 'var(--form-text)' }}>{field.label}</label>
-              <input className="form-input" type="text" value={data[field.id] || ''} onChange={e => update(field.id, e.target.value)} />
+              <label id={fieldLabelId} htmlFor={`addr-input-${field.id}`} style={{ display: 'block', fontSize: 13, marginBottom: 4, color: 'var(--form-text)' }}>{field.label}</label>
+              <input id={`addr-input-${field.id}`} className="form-input" type="text" value={data[field.id] || ''} onChange={e => update(field.id, e.target.value)} />
             </>
           )}
           {field.type === 'dropdown' && (
             <>
-              <label style={{ display: 'block', fontSize: 13, marginBottom: 4, color: 'var(--form-text)' }}>{field.label}</label>
-              <select className="form-input" value={data[field.id] || ''} onChange={e => update(field.id, e.target.value)}>
+              <label id={fieldLabelId} htmlFor={`addr-input-${field.id}`} style={{ display: 'block', fontSize: 13, marginBottom: 4, color: 'var(--form-text)' }}>{field.label}</label>
+              <select id={`addr-input-${field.id}`} className="form-input" value={data[field.id] || ''} onChange={e => update(field.id, e.target.value)}>
                 <option value="">{locale.addressSelect}</option>
                 {(field.options || '').split(',').map((opt, i) => (
                   <option key={i} value={opt.trim()}>{opt.trim()}</option>
@@ -1210,8 +1227,8 @@ function AddressInput({ step, value, onChange }) {
           )}
           {field.type === 'radio' && (
             <>
-              <label style={{ display: 'block', fontSize: 13, marginBottom: 4, color: 'var(--form-text)' }}>{field.label}</label>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <span id={fieldLabelId} style={{ display: 'block', fontSize: 13, marginBottom: 4, color: 'var(--form-text)' }}>{field.label}</span>
+              <div role="radiogroup" aria-labelledby={fieldLabelId} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
                 {(field.options || '').split(',').map((opt, i) => (
                   <label key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 14 }}>
                     <input type="radio" name={field.id} value={opt.trim()} checked={data[field.id] === opt.trim()} onChange={e => update(field.id, e.target.value)} />
@@ -1222,7 +1239,8 @@ function AddressInput({ step, value, onChange }) {
             </>
           )}
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -1278,6 +1296,20 @@ function FileUploadInput({ step, value, onChange }) {
       <div
         className={`file-dropzone ${value ? 'has-file' : ''}`}
         onClick={() => fileRef.current?.click()}
+        role="button"
+        tabIndex={0}
+        aria-label={value ? fileName : locale.fileUploadPrompt}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            // This div isn't a real <button>, so the form-wide Enter handler
+            // (which advances/submits the step, and skips real buttons/links
+            // via e.target.closest('button, a')) would otherwise also fire
+            // for this keystroke — stop it here the same way it stops for those.
+            e.stopPropagation();
+            fileRef.current?.click();
+          }
+        }}
       >
         {value ? (
           <>
@@ -1294,7 +1326,7 @@ function FileUploadInput({ step, value, onChange }) {
         )}
       </div>
       <input ref={fileRef} type="file" accept={step.accept || '*'} onChange={handleFile} style={{ display: 'none' }} />
-      {error && <p className="step-error" style={{ marginTop: 8 }}>{error}</p>}
+      {error && <p className="step-error" role="alert" style={{ marginTop: 8 }}>{error}</p>}
     </div>
   );
 }
@@ -1313,6 +1345,7 @@ function ImageSelectInput({ step, value, onChange }) {
             key={i}
             className={`form-image-option ${value === optValue ? 'selected' : ''}`}
             onClick={() => onChange(optValue)}
+            aria-pressed={value === optValue}
           >
             {optImage ? (
               <img src={optImage} alt={optLabel} className="image-option-img" />

--- a/frontend/src/locales.js
+++ b/frontend/src/locales.js
@@ -55,6 +55,10 @@ export const LOCALES = {
     dateClear: 'Clear',
     datePrevMonth: 'Previous month',
     dateNextMonth: 'Next month',
+    // Accessibility: not shown visually, only exposed to assistive tech.
+    previousStep: 'Previous question',
+    stepProgress: (current, total) => `Step ${current} of ${total}`,
+    starRating: (n, max) => `${n} out of ${max} stars`,
   },
   de: {
     next: 'Weiter',
@@ -109,5 +113,8 @@ export const LOCALES = {
     dateClear: 'Zurücksetzen',
     datePrevMonth: 'Vorheriger Monat',
     dateNextMonth: 'Nächster Monat',
+    previousStep: 'Vorherige Frage',
+    stepProgress: (current, total) => `Frage ${current} von ${total}`,
+    starRating: (n, max) => `${n} von ${max} Sternen`,
   },
 };

--- a/frontend/src/pages/EmbedView.jsx
+++ b/frontend/src/pages/EmbedView.jsx
@@ -11,13 +11,17 @@ function CookieBanner({ form, onAccept, onDecline }) {
   const primary = form.theme?.primaryColor || '#6C5CE7';
 
   return (
-    <div style={{
-      position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 9999,
-      background: '#fff', borderTop: '1px solid #e0e0e0',
-      boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
-      padding: '16px 24px',
-      display: 'flex', flexDirection: 'column', gap: 12,
-    }}>
+    <div
+      role="region"
+      aria-label="Cookie preferences"
+      style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 9999,
+        background: '#fff', borderTop: '1px solid #e0e0e0',
+        boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
+        padding: '16px 24px',
+        display: 'flex', flexDirection: 'column', gap: 12,
+      }}
+    >
       <p style={{ margin: 0, fontSize: 14, color: '#2D3436', lineHeight: 1.5 }}>{text}</p>
       <div style={{ display: 'flex', gap: 10 }}>
         <button
@@ -61,6 +65,19 @@ export default function EmbedView() {
       else root.removeAttribute('data-theme');
     };
   }, []);
+
+  // Keep the document's declared language in sync with the form's respondent-
+  // facing language, so assistive tech uses the right pronunciation/voice
+  // (WCAG 3.1.1) instead of whatever the host page's <html lang> happens to be.
+  useEffect(() => {
+    const root = document.documentElement;
+    const prev = root.getAttribute('lang');
+    root.setAttribute('lang', form?.theme?.language === 'de' ? 'de' : 'en');
+    return () => {
+      if (prev) root.setAttribute('lang', prev);
+      else root.removeAttribute('lang');
+    };
+  }, [form?.theme?.language]);
 
   useEffect(() => {
     api.getPublicForm(slug)
@@ -138,7 +155,7 @@ export default function EmbedView() {
   }, []);
 
   if (error) return <div style={{ padding: 40, textAlign: 'center' }}>Form not found</div>;
-  if (!form) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
+  if (!form) return <div style={{ padding: 40, textAlign: 'center' }} role="status" aria-live="polite">Loading...</div>;
 
   return (
     <>

--- a/frontend/src/pages/FormView.jsx
+++ b/frontend/src/pages/FormView.jsx
@@ -11,13 +11,17 @@ function CookieBanner({ form, onAccept, onDecline }) {
   const primary = form.theme?.primaryColor || '#6C5CE7';
 
   return (
-    <div style={{
-      position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 9999,
-      background: '#fff', borderTop: '1px solid #e0e0e0',
-      boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
-      padding: '16px 24px',
-      display: 'flex', flexDirection: 'column', gap: 12,
-    }}>
+    <div
+      role="region"
+      aria-label="Cookie preferences"
+      style={{
+        position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 9999,
+        background: '#fff', borderTop: '1px solid #e0e0e0',
+        boxShadow: '0 -4px 24px rgba(0,0,0,0.10)',
+        padding: '16px 24px',
+        display: 'flex', flexDirection: 'column', gap: 12,
+      }}
+    >
       <p style={{ margin: 0, fontSize: 14, color: '#2D3436', lineHeight: 1.5 }}>{text}</p>
       <div style={{ display: 'flex', gap: 10 }}>
         <button
@@ -63,6 +67,19 @@ export default function FormView({ slugProp, hostMode = false }) {
       else root.removeAttribute('data-theme');
     };
   }, []);
+
+  // Keep the document's declared language in sync with the form's respondent-
+  // facing language, so assistive tech uses the right pronunciation/voice
+  // (WCAG 3.1.1) instead of whatever the admin shell's <html lang> happens to be.
+  useEffect(() => {
+    const root = document.documentElement;
+    const prev = root.getAttribute('lang');
+    root.setAttribute('lang', form?.theme?.language === 'de' ? 'de' : 'en');
+    return () => {
+      if (prev) root.setAttribute('lang', prev);
+      else root.removeAttribute('lang');
+    };
+  }, [form?.theme?.language]);
 
   useEffect(() => {
     api.getPublicForm(slug)
@@ -130,7 +147,7 @@ export default function FormView({ slugProp, hostMode = false }) {
   }
 
   if (error) return <div style={{ padding: 40, textAlign: 'center' }}><h2>Form not found</h2></div>;
-  if (!form) return <div style={{ padding: 40, textAlign: 'center' }}>Loading...</div>;
+  if (!form) return <div style={{ padding: 40, textAlign: 'center' }} role="status" aria-live="polite">Loading...</div>;
 
   return (
     <>


### PR DESCRIPTION
## Summary

Follow-up to #94 (merged) — the accessibility item from the production-readiness review. `FormRenderer.jsx`, `FormView.jsx`, and `EmbedView.jsx` get a WCAG 2.1 AA pass:

- Question headings are programmatically associated with their field via `aria-labelledby` (single-question and combined "group" steps alike) — previously a purely visual label.
- Validation errors are announced via `role="alert"`.
- Choice-style controls (single/multi-select, yes/no, image-select, star rating) expose selected state via `aria-pressed`; star ratings get a descriptive `aria-label` ("3 out of 5 stars").
- The progress bar exposes `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` and a localized "Step N of M" label.
- The file-upload dropzone is now keyboard-operable (`role="button"`, `tabIndex`, Enter/Space triggers the file picker) — it only responded to a mouse click before.
- The "previous question" nav button (icon-only, no visible text before) gets a localized `aria-label`.
- `<html lang>` now tracks the form's respondent-facing language (EN/DE) on both `/f/:slug` and `/embed/:slug`, instead of always reporting the admin shell's language.
- Address custom-field labels (text/dropdown/radio-group) are now programmatically linked to their inputs via `htmlFor`/`aria-labelledby`.
- The cookie-consent banner and calendar get accessible group labels.
- New locale strings (`previousStep`, `stepProgress`, `starRating`) added to both EN and DE.

Also refreshed `.env.example`, which still showed `ADMIN_PASSWORD=admin123` as if it were a real default and didn't mention the new `ENCRYPTION_KEY` from #94 at all.

Version bumped 0.27.1 → 0.28.0 per CLAUDE.md convention.

## Test plan

- `cd backend && npm test` — 127/127 passing.
- `cd frontend && npm run build` — clean production build, no errors.
- **Verified live in a browser**, not just statically: started the backend against a scratch DB, seeded a form with a text/select/yes-no/rating/file-upload step via the API, ran the frontend dev server, and drove it with Playwright against the real running app. Confirmed: `<html lang>` tracks the form language, the progress bar reports correct `aria-valuenow`/label at each step, the question-heading↔group `aria-labelledby` wiring resolves to a real id, `aria-pressed` starts `false` and the choice/rating controls carry the right values, the file-upload dropzone is keyboard-focusable and Enter opens the file picker (`click()` on the hidden `<input>` fires) **without** also triggering the form's own Enter-to-advance handler (confirmed the step didn't accidentally advance/submit — the riskiest change, since the file dropzone is a `<div>` not a real `<button>`, so it doesn't get the same "skip advancing" treatment the form's global Enter handler gives real buttons/links). No new console errors beyond an expected offline Google Fonts fetch failure in the sandboxed test environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRCqwdmFSPg4exjy7k1wyg)_