### PR TITLE
Fix broken mobile admin nav (off-canvas drawer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenFlow are documented in this file.
 
+## [0.29.0] - 2026-08-12
+
+### Fixed
+- **Responsive admin nav on mobile** (`App.jsx`, `styles/global.css`). Below 768px the sidebar used to squash itself into a single horizontal row (`flex-direction: row`, `height: auto`), which made the nav links side-scroll and clipped the account email / theme toggle / log out / version-and-GitHub footer block out of view. It's replaced with a proper off-canvas drawer: a sticky top bar (logo + hamburger) opens the sidebar as a full-height slide-in panel with a dimmed backdrop, keeping the sidebar's normal vertical layout (stacked nav links, footer pinned to the bottom via `margin-top: auto`). The drawer closes on backdrop click or route change. Desktop layout (>768px) is unchanged.
+
 ## [0.28.0] - 2026-08-12
 
 ### Accessibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **OpenFlow** is an open-source, self-hosted form builder for lead generation. It's a Typeform/Heyflow alternative with a multi-step form builder, conditional logic, integrations (webhooks, email, Google Sheets, Google Ads), analytics, and a WordPress plugin.
 
-**Current Version**: 0.28.0 (see version badge in README.md and CHANGELOG.md)
+**Current Version**: 0.29.0 (see version badge in README.md and CHANGELOG.md)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 OpenFlow v0.28.0
+# 🌊 OpenFlow v0.29.0
 > Open-source form builder for lead generation. A self-hosted alternative to Typeform and Heyflow.
 
 ## 📚 Table of Contents

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-backend",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-backend",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^11.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-backend",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "OpenFlow - Form builder backend",
   "main": "src/index.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openflow-frontend",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openflow-frontend",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openflow-frontend",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ export default function App() {
   const [loading, setLoading] = useState(true);
   const [theme, setTheme] = useState(getInitialTheme);
   const [branding, setBranding] = useState({ logoVisible: true, logoUrl: '' });
+  const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -30,6 +31,10 @@ export default function App() {
       api.getSettings().then(d => { if (d.settings?.branding) setBranding(b => ({ ...b, ...d.settings.branding })); }).catch(() => {}),
     ]).finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -63,7 +68,19 @@ export default function App() {
 
   return (
     <div className="admin-layout">
-      <aside className="admin-sidebar">
+      <header className="admin-topbar">
+        <span className="admin-topbar-brand"><LogoMark size={24} className="logo-mark" />OpenFlow</span>
+        <button
+          className="admin-menu-toggle"
+          onClick={() => setMenuOpen(o => !o)}
+          aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={menuOpen}
+        >
+          {menuOpen ? '✕' : '☰'}
+        </button>
+      </header>
+      {menuOpen && <div className="admin-sidebar-backdrop" onClick={() => setMenuOpen(false)} />}
+      <aside className={`admin-sidebar${menuOpen ? ' open' : ''}`}>
         <h1><LogoMark size={28} className="logo-mark" />OpenFlow</h1>
         <nav>
           <Link to="/" className={location.pathname === '/' ? 'active' : ''}>Forms</Link>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -152,6 +152,19 @@ input, select, textarea {
   min-height: 100vh;
 }
 
+/* Mobile top bar + drawer controls (hidden on desktop) */
+.admin-topbar {
+  display: none;
+}
+
+.admin-menu-toggle {
+  display: none;
+}
+
+.admin-sidebar-backdrop {
+  display: none;
+}
+
 /* Cards */
 .card {
   background: var(--card);
@@ -424,24 +437,78 @@ input, select, textarea {
   .admin-layout {
     flex-direction: column;
   }
-  .admin-sidebar {
-    width: 100%;
-    padding: 16px;
-    flex-direction: row;
-    align-items: center;
-    height: auto;
-    position: relative;
-  }
-  .admin-sidebar h1 {
-    margin: 0 16px 0 0;
-  }
-  .admin-sidebar nav {
+
+  /* Sticky mobile header with brand + hamburger, replaces the desktop sidebar in flow */
+  .admin-topbar {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--sidebar-bg);
+    color: white;
+    position: sticky;
+    top: 0;
+    z-index: 30;
+  }
+
+  .admin-topbar-brand {
+    display: flex;
+    align-items: center;
     gap: 8px;
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 17px;
+    letter-spacing: -0.5px;
   }
-  .admin-sidebar nav a {
-    margin: 0;
+
+  .admin-menu-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    background: none;
+    border: none;
+    color: white;
+    font-size: 20px;
+    line-height: 1;
+    border-radius: 8px;
   }
+
+  .admin-menu-toggle:hover {
+    background: rgba(255,255,255,0.1);
+  }
+
+  .admin-sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.45);
+    z-index: 35;
+  }
+
+  /* Sidebar becomes an off-canvas drawer; it keeps its desktop flex-column
+     layout so nav links stack (no more horizontal scrolling) and the
+     account/theme/logout/version footer stays pinned to the bottom via
+     margin-top:auto instead of being squeezed into a single row. */
+  .admin-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: min(280px, 82vw);
+    height: 100vh;
+    padding: 24px 16px;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    z-index: 40;
+    box-shadow: 2px 0 16px rgba(0,0,0,0.2);
+  }
+
+  .admin-sidebar.open {
+    transform: translateX(0);
+  }
+
   .admin-main {
     padding: 16px;
   }


### PR DESCRIPTION
## Summary

The admin sidebar's mobile breakpoint (`@media (max-width: 768px)`) collapsed the sidebar into a single horizontal row (`flex-direction: row`, `height: auto`). That:

- Turned the nav links into a side-scrolling strip.
- Squeezed the account email / theme toggle / log out button / version+GitHub footer block off-row, clipping it out of view.

Replaced it with a proper off-canvas drawer:

- A new sticky mobile top bar (`.admin-topbar`) shows the OpenFlow brand and a hamburger toggle (`.admin-menu-toggle`).
- Tapping it slides the existing sidebar in from the left as a full-height drawer (`.admin-sidebar.open`) over a dimmed backdrop (`.admin-sidebar-backdrop`), which closes it on click.
- The sidebar keeps its normal desktop **vertical** flex layout inside the drawer (no more `flex-direction: row` override), so nav links stack instead of scrolling sideways, and the footer (account email, theme toggle, log out, version/GitHub link) stays pinned to the bottom via the existing `margin-top: auto` and is fully visible/scrollable.
- The drawer auto-closes on route change (`useEffect` on `location.pathname`).
- Desktop layout (`>768px`) is untouched — verified via screenshot.

Also includes the routine version bump required by `CLAUDE.md` (0.28.0 → 0.29.0: README badge, CHANGELOG entry, backend/frontend `package.json` + lockfiles, `CLAUDE.md`).

## Test plan

- [x] `cd frontend && npm run build` — succeeds
- [x] Ran the app locally (backend `npm run dev` + frontend Vite dev server), logged in, and used Playwright at a 390×844 mobile viewport to confirm:
  - Closed state shows the sticky top bar only.
  - Opening the drawer shows all nav items (Forms, Analytics, Users, Settings, Backup for an admin) stacked vertically, no horizontal scrolling, with the account email / theme toggle / log out / version+GitHub footer fully visible at the bottom.
  - Desktop viewport (1280×900) renders identically to before.
- [ ] Backend Jest suite (`backend/npm test`) — not run to completion in this session (unrelated to this frontend-only change); no backend files were touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P4uC8kEBtHfQEFE2QkSue2)_